### PR TITLE
Make the Github repository the authoritative source for GTFS Realtime

### DIFF
--- a/gtfs-realtime/README.md
+++ b/gtfs-realtime/README.md
@@ -1,0 +1,6 @@
+This directory contains GTFS Realtime Specification and documentation.
+
+### Quick links
+- [GTFS Realtime protocol buffer definition](proto/gtfs-realtime.proto)
+- [Documentation](spec/en)
+

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -20,7 +20,7 @@
 // arrival times.
 //
 // This protocol is published at:
-// https://developers.google.com/transit/gtfs-realtime/
+// https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto
 
 syntax = "proto2";
 option java_package = "com.google.transit.realtime";

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -20,7 +20,7 @@
 // arrival times.
 //
 // This protocol is published at:
-// https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto
+// https://github.com/google/transit/tree/master/gtfs-realtime
 
 syntax = "proto2";
 option java_package = "com.google.transit.realtime";


### PR DESCRIPTION
Make the Github repository the authoritative source for gtfs-realtime.proto.