### PR TITLE
Clarify that stops upstream of predictions have unknown delay

### DIFF
--- a/gtfs-realtime/spec/en/trip-updates.md
+++ b/gtfs-realtime/spec/en/trip-updates.md
@@ -32,6 +32,7 @@ For the same trip instance, three [StopTimeUpdates](reference.md#StopTimeUpdate)
 
 This will be interpreted as:
 
+*   stop_sequences 1,2 have unknown delay.
 *   stop_sequences 3,4,5,6,7 have delay of 300 seconds.
 *   stop_sequences 8,9 have delay of 60 seconds.
 *   stop_sequences 10,..,20 have unknown delay.


### PR DESCRIPTION
In the process of attempting to clarify behavior for producers as to when they are allowed to drop per-stop predictions (https://github.com/google/transit/pull/16), it became apparent that at least one vendor was assuming that when using per-stop predictions, consumers could either propagate predictions upstream or hold over predictions from a previous feed update and show these to end users.

This patch clarifies that in the absence of any predictions upstream of a stop-specific prediction, it should be assumed that these upstream stops have an unknown delay.