### PR TITLE
Better cross-linking for PR and Google Groups post

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -5,7 +5,7 @@ The official specification, reference and documentation are written in English. 
 
 1. Create a git branch with update of all relevant parts of protocol definition, specification and documentation files (except for translations).
 1. Create pull request on https://github.com/google/transit. Pull request must contain an extended description of the patch. The creator of the pull request becomes the _advocate_.
-1. Once pull request is registered, it must be announced by its advocate in the [GTFS Changes mailing list](https://groups.google.com/forum/#!forum/gtfs-changes). Once announced, the pull request is considered a proposal.
+1. Once pull request is registered, it must be announced by its advocate in the [GTFS Changes mailing list](https://groups.google.com/forum/#!forum/gtfs-changes), including a link to the pull request. Once announced, the pull request is considered a proposal.  The pull request should also be edited to contain a link to the Google Groups announcement so they can easily be cross-referenced.
   - Since the advocate is a contributor, they must sign the [Contributor License Agreement](../CONTRIBUTING.md) before pull request can be accepted.
 1. The discussion of the proposal follows. Pull request comments should be used as the sole discussion forum.
   - The discussion lasts for as long as the advocate feels necessary, but must be at least 7 calendar days.
@@ -29,6 +29,7 @@ The official specification, reference and documentation are written in English. 
   - Google is committed to merging the voted upon version of the pull request (provided that the contributors have signed the [CLA](../CONTRIBUTING.md)), and performing the pull request within 5 business days.
   - Translations must not be included into the original pull request.
     Google is responsible for eventually updating relevant translations into supported languages, but pure translation pull requests from the community are welcome and will be accepted as soon as all editorial comments are addressed.
+1. The final result of the pull request (accepted or abandoned) should be announced on the same Google Groups thread where the pull request was originally announced.
 
 ### Guiding Principles
 In order to preserve the original vision of GTFS, a number of guiding principles have been established to take into consideration when extending the spec:


### PR DESCRIPTION
A proposal for improved communication regarding the Github/Google Groups workflow for the Change process:
* Make sure each has a link to the other
* Announce the PR result (accepted or abandoned) in the same Google Group thread

First mentioned in https://github.com/google/transit/pull/30#issuecomment-268593267.

Announced on GTFS Changes Google Group at https://groups.google.com/forum/#!topic/gtfs-changes/bqXHRIBdP4E.

cc @mmorang