### PR TITLE
Blocks and service days - Clarify relationship of block_id & service_id

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of a single trip or or many sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -175,11 +175,11 @@ File: **Required**
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one bicycle |
 |   |  | * **2** - indicates that no bicycles are allowed on this trip |
 
-The example below is valid, with distinct blocks every day of the week.
-
 #### Example showing blocks and service day
 
-| route_id | trip_id | service_id                     | block_id | first stop time [not part of trips.txt] | last stop time [not part of trips.txt] |
+The example below is valid, with distinct blocks every day of the week.
+
+| route_id | trip_id | service_id                     | block_id | <span style="font-weight:normal">*(first stop time)*</span> | <span style="font-weight:normal">*(last stop time)*</span> |
 |----------|---------|--------------------------------|----------|-----------------------------------------|-------------------------|
 | red      | trip_1  | mon-tues-wed-thurs-fri-sat-sun | red_loop | 22:00:00                                | 22:55:00                |
 | red      | trip_2  | fri-sat-sun                    | red_loop | 23:00:00                                | 23:55:00                |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, where a passenger can transfer from one trip to the next just by staying in the vehicle. The **block_id** must be referenced by two or more trips in trips.txt. |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |
@@ -174,6 +174,22 @@ File: **Required**
 |  bikes_allowed | Optional | 0 (or empty) - indicates that there is no bike information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one bicycle |
 |   |  | * **2** - indicates that no bicycles are allowed on this trip |
+
+The example below is valid, with distinct blocks every day of the week.
+
+#### Example showing blocks and service day
+
+| route_id | trip_id | service_id                     | block_id | first stop time [not part of trips.txt] | last stop time [not part of trips.txt] |
+|----------|---------|--------------------------------|----------|-----------------------------------------|-------------------------|
+| red      | trip_1  | mon-tues-wed-thurs-fri-sat-sun | red_loop | 22:00:00                                | 22:55:00                |
+| red      | trip_2  | fri-sat-sun                    | red_loop | 23:00:00                                | 23:55:00                |
+| red      | trip_3  | fri-sat                        | red_loop | 24:00:00                                | 24:55:00                |
+| red      | trip_4  | mon-tues-wed-thurs             | red_loop | 20:00:00                                | 20:50:00                |
+| red      | trip_5  | mon-tues-wed-thurs             | red_loop | 21:00:00                                | 21:50:00                |
+
+Notes on above table:
+* On Friday into Saturday morning, for example, a single vehicle operates trip_1, trip_2, and trip_3 (10:00 PM through 12:55 AM). Note that the last trip occurs on Saturday, 12:00 AM to 12:55 AM, but is part of the Friday “service day” because the times are 24:00:00 to 24:55:00.
+* On Monday, Tuesday, Wednesday, and Thursday, a single vehicle operates trip_1, trip_4, and trip_5 in a block from 8:00 PM to 10:55 PM.
 
 ### stop_times.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of a single trip or or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of a single trip or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of two or more sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -166,7 +166,7 @@ File: **Required**
 |   |  | * `trip_id,...,trip_headsign,direction_id` |
 |   |  | * `1234,...,to Airport,0` |
 |   |  | * `1505,...,to Downtown,1` |
-|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of a single trip or or many sequential trips made using the same vehicle, defined by shared service day and block_id. The block_id must be referenced by two or more trips in trips.txt. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
+|  block_id | Optional | The **block_id** field identifies the block to which the trip belongs. A block consists of a single trip or or many sequential trips made using the same vehicle, defined by shared service day and block_id. A block_id can have trips with different service days, making distinct blocks. (See [example below](#example-showing-blocks-and-service-day)) |
 |  shape_id | Optional | The **shape_id** field contains an ID that defines a shape for the trip. This value is referenced from the [shapes.txt](#shapestxt) file. The shapes.txt file allows you to define how a line should be drawn on the map to represent a trip. |
 |  wheelchair_accessible | Optional | * **0** (or empty) - indicates that there is no accessibility information for the trip |
 |   |  | * **1** - indicates that the vehicle being used on this particular trip can accommodate at least one rider in a wheelchair |


### PR DESCRIPTION
It was previously unclear how a block can be defined across service days.

New/added text: "A block consists of a single trip or or many sequential trips made using the same vehicle, defined by shared service day and block_id."

Removed: "The block_id must be referenced by two or more trips in trips.txt."

Note: This proposed change introduces the term of "service day" (see https://github.com/google/transit/issues/43 for discussion).