### PR TITLE
Add field stops.relative_position

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -96,6 +96,12 @@ File: **Required**
 |  stop_id | **Required** | The **stop_id** field contains an ID that uniquely identifies a stop, station, or station entrance. Multiple routes may use the same stop. The **stop_id** is used by systems as an internal identifier of this record (e.g., primary key in database), and therefore the **stop_id** must be dataset unique.  |  |  |
 |  stop_code | Optional | The **stop_code** field contains short text or a number that uniquely identifies the stop for passengers. Stop codes are often used in phone-based transit information systems or printed on stop signage to make it easier for riders to get a stop schedule or real-time arrival information for a particular stop.  The **stop_code** field contains short text or a number that uniquely identifies the stop for passengers. The **stop_code** can be the same as **stop_id** if it is passenger-facing. This field should be left blank for stops without a code presented to passengers. |  |  |
 |  stop_name | **Required** | The **stop_name** field contains the name of a stop, station, or station entrance. Please use a name that people will understand in the local and tourist vernacular. |  |  |
+|  relative_position | Optional | The **relative_position** field contains the relative position of the stop to the stop name. Allowed values are: |  |  |
+| | | - blank: no position defined (default value); |  |  |
+| | | - **NS**: near side of the intersection; |  |  |
+| | | - **FS**: far side of the intersection; |  |  |
+| | | - **AT**: stop is at position; |  |  |
+| | | - **OP**: stop is across the street. |  |  |
 |  stop_desc | Optional | The **stop_desc** field contains a description of a stop. Please provide useful, quality information. Do not simply duplicate the name of the stop. |  |  |
 |  stop_lat | **Required** | The **stop_lat** field contains the latitude of a stop, station, or station entrance. The field value must be a valid WGS 84 latitude. |  |  |
 |  stop_lon | **Required** | The **stop_lon** field contains the longitude of a stop, station, or station entrance. The field value must be a valid WGS 84 longitude value from -180 to 180. |  |  |


### PR DESCRIPTION
#### Current issue
Currently some agencies put in `stops.stop_name` the information about the relative position of the stop (near side, far side, ...) because they feel that this information is relevant for the end user, even if it isn't included in the `stop_name` displayed in the street, on the maps or in the bus.

Examples:
  - Valley Metro (Phoenix, US-AZ):
    - `EB W VAN BUREN AV NS N 87TH AV`, 
    - `SB N 67TH AV FS W CORRINE DR`.
  - Halifax Transit (Halifax, CA-NS): 
    - `Mt Edward Rd After Gerald St`, 
    - `Mt Edward Rd Before John Cross Dr`, 
    - `Mt Edward Rd Opposite John Cross Dr`.
  - RIPTA (Providence, US-RI): 
    - `BOON NS CONGDON`, 
    - `S PIER OPP 172 S PIER`.
  - LTC (London, CA-ON): 
    - `Adelaide & Kipps Lane FS NB`, 
    - `Adelaide & Kipps Lane NS SB`.

Some agencies put this information in an extra field, which isn't part of the spec, which complicate the use of that data for GTFS consumers.

Examples:
  - Madison Metro Transit (Madison, US-WI) uses a field `stops.position` which contains: "nearside", "opposite", "adjacent" or "farside".
  - TriMet (Portland, US-OR) uses also a field `stops.position`, but the values are "Nearside", "At", "Opposite" and "Farside".

#### Goals
1) Allow the agencies to provide a clean `stop_name`, by providing the stop location in another field.
2) Allow the blind users to have standardized information about the stop position.

#### Proposal
> (Optional) The **relative_position** field contains the relative position of the stop to the stop name. Allowed values are:
> - blank: no position defined (default value);
> - **NS**: near side of the intersection;
> - **FS**: far side of the intersection;
> - **AT**: stop is at position;
> - **OP**: stop is across the street.

This pull request is a merge of different sources:
- The GTFS+ proposal of a `stop_attributes.relative_position`:  http://www.transitwiki.org/TransitWiki/images/e/e7/GTFS+_Additional_Files_Format_Ver_1.7.pdf
- The TriMet proposal (Portland, US-OR) of a `stops.position`: https://groups.google.com/forum/#!topic/gtfs-changes/LlduFqXj9pg

[Edited 2017-02-16 20:19 EST: add "Current issue" and "Goals" sections]