### PR TITLE
Clarify that a proposer's vote does not count towards total

### DIFF
--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -19,7 +19,7 @@ The official specification, reference and documentation are written in English. 
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   - Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
-  - The proposer's vote does not count towards the 3 vote total.  For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
+  - The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   - Votes against shall be motivated, and ideally provide actionable feedback.
   - If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.

--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -19,6 +19,7 @@ The official specification, reference and documentation are written in English. 
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   - Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
+  - The proposer's vote does not count towards the 3 vote total.  For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   - Votes against shall be motivated, and ideally provide actionable feedback.
   - If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -19,7 +19,7 @@ The official specification, reference and documentation are written in English. 
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   - Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
-  - The proposer's vote does not count towards the 3 vote total.  For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
+  - The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   - Votes against shall be motivated, and ideally provide actionable feedback.
   - If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -19,6 +19,7 @@ The official specification, reference and documentation are written in English. 
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   - Votes before the start of the voting period are not considered.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
+  - The proposer's vote does not count towards the 3 vote total.  For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   - Votes against shall be motivated, and ideally provide actionable feedback.
   - If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.


### PR DESCRIPTION
As far as I can tell, it's not currently clear whether or not the proposer's vote is counted towards the total 3 yes votes needed for a proposal to be accepted for both GTFS and GTFS-rt.  For example, in https://github.com/google/transit/pull/46 there were two yes votes by users other than the proposer (me) during the voting period.

This pull request clarifies that a proper's vote does not count towards the total needed 3 yes votes.

Hopefully in the vote on this we can get it to pass by more than 2 other votes :).

Posted to gtfs-changes at https://groups.google.com/forum/#!topic/gtfs-changes/8jONl-MbyY0.