### PR TITLE
Revision of the Spanish translation of GTFS-realtime docs

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -47,6 +47,13 @@ Version 1.0 of the feed specification is discussed and documented on this site.
 
 The contents of a feed message. Each message in the stream is obtained as a response to an appropriate HTTP GET request. A realtime feed is always defined with relation to an existing GTFS feed. All the entity ids are resolved with respect to the GTFS feed.
 
+A feed depends on these external configurations:
+
+*   The corresponding GTFS feed.
+*   Feed application (updates, positions, or alerts).
+    NOTE: A feed should contain only items for the specified applications: processing ignores other entities.
+*   Polling frequency (controlled by min_update_delay and max_update_delay).
+
 #### Fields
 
 |_**Field Name**_ | _**Type**_ | _**Cardinality**_ | _**Description**_ |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -73,13 +73,6 @@ Fields labeled as **experimental** are subject to change and not yet formally ad
 
 The contents of a feed message. Each message in the stream is obtained as a response to an appropriate HTTP GET request. A realtime feed is always defined with relation to an existing GTFS feed. All the entity ids are resolved with respect to the GTFS feed.
 
-A feed depends on these external configurations:
-
-*   The corresponding GTFS feed.
-*   Feed application (updates, positions, or alerts).
-    NOTE: A feed should contain only items for the specified applications: processing ignores other entities.
-*   Polling frequency (controlled by min_update_delay and max_update_delay).
-
 #### Fields
 
 | _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |

--- a/gtfs-realtime/spec/es/README.md
+++ b/gtfs-realtime/spec/es/README.md
@@ -1,10 +1,10 @@
 GTFS en tiempo real es una especificación de feed que permite que las empresas de tranporte público proporcionen actualizaciones en tiempo real sobre su flota a los programadores de la aplicación. Es una extensión de [GTFS](https://developers.google.com/transit/gtfs/reference) (Especificación general de feeds de transporte público), un formato de datos abierto para los horarios de transporte público y la información geográfica asociada. GTFS en tiempo real fue diseñado en torno a la facilidad de implementación, buena interoperabilidad GTFS y un enfoque en la información al pasajero.
 
-La especificación fue diseñada a través de una asociación de las empresas miembro de las [Actualizaciones del transporte público en tiempo real](https://developers.google.com/transit/google-transit#LiveTransitUpdates) iniciales, diferentes programadores de transporte público y Google. La especificación está publicada bajo la licencia [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+La especificación fue diseñada a través de la asociación de las empresas que eran inicialmente miembros de [Actualizaciones del transporte público en tiempo real](https://developers.google.com/transit/google-transit#LiveTransitUpdates), diferentes programadores de transporte público y Google. La especificación está publicada bajo la licencia [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 ## ¿Cómo empiezo?
 
-1.  Sigue leyendo el resumen general a continuación.
+1.  Sigue leyendo el resumen general.
 2.  Decide qué [tipos de feed](feed-types.md) proporcionarás.
 3.  Consulta los [ejemplos de feeds](examples/).
 4.  Crea tus propios feeds mediante la [referencia](reference.md).
@@ -18,9 +18,9 @@ La especificación es compatible actualmente con los siguientes tipos de informa
 *   **Alertas del servicio**: traslados de paradas o eventos imprevistos que afectan una estación, ruta o toda la red
 *   **Posiciones del vehículo**: información sobre los vehículos, incluidos la ubicación y el nivel de congestión
 
-Las actualizaciones de cada tipo se proporcionan en un feed separado. Los feeds se muestran a través de HTTP y se actualizan con frecuencia. El archivo en sí es un archivo binario normal, por lo que cualquier tipo de servidor web puede alojar y mostrar el archivo (es posible utilizar otros protocolos de transferencia también). Alternativamente, los servidores de aplicaciones web también se podrían utilizar, los cuales devolverán el feed como una respuesta a una solicitud GET de HTTP válida. No hay limitaciones en cuanto a la frecuencia ni al método exacto de cómo el feed debe ser actualizado o recuperado.
+Las actualizaciones de cada tipo se proporcionan en un feed separado. Los feeds se muestran a través de HTTP y se actualizan con frecuencia. El archivo en sí es un archivo binario normal, por lo que cualquier tipo de servidor web puede alojar y mostrar el archivo (es posible utilizar otros protocolos de transferencia también). También se podrían utilizar servidores de aplicaciones web, los cuales devolverían el feed como una respuesta a una solicitud GET de HTTP válida. No hay limitaciones en cuanto a la frecuencia ni a los métodos exactos con los que el feed debe ser actualizado o recuperado.
 
-Ya que GTFS en tiempo real te permite presentar el estado _real_ de tu flota, el feed debe ser actualizado con frecuencia, de preferencia cuando se ingresen nuevos datos de tu sistema de ubicación automática de vehículos.
+Ya que GTFS en tiempo real te permite presentar el estado _real_ de tu flota, el feed debe ser actualizado con frecuencia, preferentemente cuando se reciban nuevos datos del sistema de ubicación automática de vehículos.
 
 [Más información sobre los tipos de feed...](feed-types.md)
 
@@ -36,7 +36,7 @@ Los búferes de protocolo son un mecanismo de lenguaje y plataforma neutral para
 
 La jerarquía de los elementos y las definiciones de su tipo están especificadas en el archivo [gtfs-realtime.proto](gtfs-realtime.proto).
 
-Este archivo de texto se utiliza para generar las bibliotecas necesarias en tu lenguaje de programación seleccionado. Estas bibliotecas proporcionan las clases y funciones necesarias para generar feeds GTFS en tiempo real válidos. Las bibliotecas no solo hacen que la creación del feed sea más fácil, sino que también garantizan que solo se produzcan feeds válidos.
+Este archivo de texto se utiliza para generar las bibliotecas necesarias en el lenguaje de programación que se elija. Estas bibliotecas proporcionan las clases y funciones necesarias para generar feeds GTFS en tiempo real válidos. Las bibliotecas no solo hacen que la creación del feed sea más fácil, sino que también garantizan que solo se produzcan feeds válidos.
 
 [Más información sobre la estructura de los datos.](reference.md)
 
@@ -47,4 +47,3 @@ Para participar en los debates sobre GTFS en tiempo real y sugerir cambios y adi
 ## Google Maps y Actualizaciones de transporte público en tiempo real
 
 Una de las posibles aplicaciones que utiliza GTFS en tiempo real es [Actualizaciones de transporte público en tiempo real](https://developers.google.com/transit/google-transit#LiveTransitUpdates), una función de Google Maps que proporciona a los usuarios información de transporte público en tiempo real. Si trabajas para una empresa de transporte público que está interesada en proporcionar actualizaciones en tiempo real para Google Maps, visita la [Página de socios de Google Transit](http://maps.google.com/help/maps/transit/partners/live-updates.html).
-

--- a/gtfs-realtime/spec/es/examples/README.md
+++ b/gtfs-realtime/spec/es/examples/README.md
@@ -1,4 +1,4 @@
-Los siguientes ejemplos muestran una representación textual de los feeds. Durante el desarrollo, es más conveniente producir una salida de búfer del protocolo ASCII para una depuración más fácil. Puedes comparar tu salida de texto con estos ejemplos para comprobar la validez de los datos.
+Los siguientes ejemplos muestran una representación textual de los feeds. Durante el desarrollo, es conveniente producir búferes de protocolo en formato ASCII para que la depuración resulte más sencilla. Puedes comparar tus archivos de texto resultantes con estos ejemplos para comprobar la validez de los datos:
 
 *   [Alertas de Google](alerts.asciipb)
 *   [Actualización de viaje (conjunto de datos completo)](trip-updates-full.asciipb)

--- a/gtfs-realtime/spec/es/feed-types.md
+++ b/gtfs-realtime/spec/es/feed-types.md
@@ -1,10 +1,10 @@
-La especificación GTFS en tiempo real admite el envío de tres tipos diferentes de datos en tiempo real. Si bien la sintaxis del archivo [gtfs-realtime.proto](gtfs-realtime.proto) permite que se mezclen distintos tipos de entidades para un feed, solo se puede usar un tipo de entidad por feed. Los resúmenes se ofrecen a continuación, con la documentación completa proporcionada en la sección correspondiente.
+La especificación GTFS en tiempo real admite el envío de tres tipos diferentes de datos en tiempo real. Si bien la sintaxis del archivo [gtfs-realtime.proto](gtfs-realtime.proto) permite que se mezclen distintos tipos de entidades para un único feed, solo se puede usar un tipo de entidad por feed. Puedes encontrar resúmenes más abajo, teniendo la documentación completa en la sección correspondiente.
 
 ## Actualizaciones de viaje
 
 #### "El autobús X tiene una demora de cinco minutos".
 
-Las actualizaciones de viaje ofrecen información acerca de fluctuaciones en el horario. Esperamos recibir actualizaciones de viaje para todos los viajes programados cuya duración se puede predecir en tiempo real. Estas actualizaciones ofrecerían un horario de llegada o salida para las diferentes paradas de la ruta. Las actualizaciones de viaje también pueden brindar información en situaciones más complejas, como cuando los viajes se cancelan o agregan al programa, o como cuando su trayecto se modifica.
+Las actualizaciones de viaje ofrecen información acerca de fluctuaciones en el horario. Esperamos recibir actualizaciones de viaje de todos los viajes programados cuya duración se puede predecir en tiempo real. Estas actualizaciones ofrecerían un horario de llegada o salida para las diferentes paradas de la ruta. Las actualizaciones de viaje también pueden brindar información en situaciones más complejas, como cuando los viajes se cancelan o agregan al programa, o como cuando su trayecto se modifica.
 
 [Más información acerca de las Actualizaciones de viaje...](trip-updates.md)
 
@@ -12,7 +12,7 @@ Las actualizaciones de viaje ofrecen información acerca de fluctuaciones en el 
 
 #### "La estación Y está cerrada por tareas de construcción".
 
-Las alertas de servicio ofrecen información acerca de los problemas más graves que puede sufrir una entidad en particular. En general, se expresan a través de una descripción textual de la interrupción.
+Las alertas de servicio ofrecen información acerca de problemas más graves que puede sufrir una entidad en particular. En general, se expresan a través de una descripción textual de la interrupción.
 
 Pueden representar los problemas que sufren:
 
@@ -31,6 +31,6 @@ Una alerta de servicio a menudo consiste en una descripción textual del problem
 
 La posición de un vehículo ofrece datos básicos acerca de un vehículo en particular de la red.
 
-La información más importante consiste en la latitud y longitud donde se encuentra el vehículo. Sin embargo, también podemos usar datos acerca de las lecturas del cuentakilómetros y velocidad actuales del vehículo.
+La información más importante consiste en la latitud y longitud donde se encuentra el vehículo. Sin embargo, también podemos usar las lecturas de cuentakilómetros y velocidad actuales del vehículo.
 
 [Más información acerca las actualizaciones de las Posiciones de los vehículos...](vehicle-positions.md)

--- a/gtfs-realtime/spec/es/gtfs-realtime.proto
+++ b/gtfs-realtime/spec/es/gtfs-realtime.proto
@@ -158,7 +158,7 @@ message TripUpdate {
   // La incertidumbre se aplica de la misma forma tanto al tiempo como a la
   // demora.  La incertidumbre especifica el error esperado en una demora real
   // (pero ten en cuenta, que todavía no definimos su significado estadístico
-  // preciso). Es posible que la incertidumbre sea 0, por ejemplo, para los
+  // concreto). Es posible que la incertidumbre sea 0, por ejemplo, para los
   // trenes que funcionan con un control de horarios por computadora.
   message StopTimeEvent {
     // La demora (en segundos) puede ser positiva (significa que el vehículo

--- a/gtfs-realtime/spec/es/reference.md
+++ b/gtfs-realtime/spec/es/reference.md
@@ -1,6 +1,6 @@
-Un feed GTFS en tiempo real permite que las empresas de transporte público brinden a los consumidores información en tiempo real acerca de las interrupciones de sus servicios (estaciones cerradas, líneas que no funcionan, demoras importantes, etc.), la ubicación de sus vehículos y tiempos de llegada esperados. 
+Un feed GTFS en tiempo real permite que las empresas de transporte público brinden a los consumidores información en tiempo real acerca de las interrupciones de sus servicios (estaciones cerradas, líneas que no funcionan, demoras importantes, etc.), la ubicación de sus vehículos y tiempos de llegada esperados.
 
-Las especificaciones de la versión 1.0 del feed se abordan y documentan en este sitio.
+Las especificaciones de la versión 1.0 del feed se abordan y documentan aquí.
 
 ### Definiciones de términos
 
@@ -8,6 +8,7 @@ Las especificaciones de la versión 1.0 del feed se abordan y documentan en este
 *   **repetido**: cero o más
 *   **mensaje**: tipo complejo
 *   **enum.**: lista de valores fijos
+*   **experimental**: campo experimental, sujeto a cambios. Podrá ser formalmente adoptado más adelante.
 
 ## Índice de elementos
 
@@ -40,7 +41,7 @@ Las especificaciones de la versión 1.0 del feed se abordan y documentan en este
 
 ## _mensaje_ FeedMessage
 
-El contenido de un mensaje de feed. Cada mensaje en el flujo de datos se obtiene como una respuesta a una solicitud HTTP GET adecuada. Un feed en tiempo real siempre se define en relación con un feed GTFS existente. Todos los ID de entidades se resuelven en relación con el feed GTFS. 
+El contenido de un mensaje de feed. Cada mensaje en el flujo de datos se obtiene como una respuesta a una solicitud HTTP GET adecuada. Un feed en tiempo real siempre se define en relación con un feed GTFS existente. Todos los ID de entidades se resuelven en relación con el feed GTFS.
 
 Un feed depende de algunas configuraciones externas:
 
@@ -57,7 +58,7 @@ Un feed depende de algunas configuraciones externas:
 
 ## _mensaje_ FeedHeader
 
-Metadatos sobre un feed, incluido en los mensajes del feed
+Metadatos sobre un feed, incluido en los mensajes del feed:
 
 ### Campos
 
@@ -65,14 +66,14 @@ Metadatos sobre un feed, incluido en los mensajes del feed
 |------------------------|------------|--------------------|-------------------|
 | **gtfs_realtime_version** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | obligatorio | Especificación de la versión del feed. La versión actual es 1.0. |
 | **incrementality** | [Incrementality](#Incrementality) | opcional |
-| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Esta marca de tiempo identifica el momento en que se ha creado el contenido de este feed (en la hora del servidor). En la hora de POSIX (es decir, cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). Para evitar el desvío de tiempos entre los sistemas que producen y que consumen información en tiempo real, se recomienda derivar la marca de tiempo desde un servidor de tiempo. Es absolutamente aceptable usar servidores de estrato 3 o, incluso, inferiores, porque las diferencias de tiempo de hasta un par de segundos son tolerables. |
+| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Esta marca de tiempo identifica el momento en que se ha creado el contenido de este feed (en la hora del servidor). En POSIX time (es decir, cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). Para evitar el desvío de tiempos entre los sistemas que producen y que consumen información en tiempo real, se recomienda derivar la marca de tiempo desde un servidor de tiempo. Es completamente aceptable usar Stratum 3 o incluso servidores strata inferiores, porque diferencias de tiempo de hasta un par de segundos son tolerables. |
 
 ## _enum._ Incrementality
 
 Determina si la búsqueda actual es incremental.
 
 *   **FULL_DATASET**: la actualización de este feed sobrescribirá toda la información en tiempo real anterior para el feed. Por lo tanto, se espera que esta actualización proporcione un resumen completo de toda la información en tiempo real conocida.
-*   **DIFFERENTIAL**: en este momento, este modo **no está admitido** y su comportamiento **no se especifica** para los feeds que usan este modo. Existen debates sobre la [lista de correo](http://groups.google.com/group/gtfs-realtime) de GTFS en tiempo real, relacionados con la especificación completa del comportamiento del modo DIFFERENTIAL, y la documentación se actualizará cuando esos debates finalicen.
+*   **DIFFERENTIAL**: en este momento, este modo **no tiene soporte** y su comportamiento es **indefinido** para los feeds que lo usan. Existen debates en la [lista de correo](http://groups.google.com/group/gtfs-realtime) de GTFS en tiempo real relacionados con la especificación completa del comportamiento del modo DIFFERENTIAL, y la documentación se actualizará cuando esos debates finalicen.
 
 ### Valores
 
@@ -97,7 +98,7 @@ La definición (o actualización) de una entidad en el feed de transporte públi
 
 ## _mensaje_ TripUpdate
 
-Actualización en tiempo real del progreso de un vehículo en un viaje. También consulta el debate general del [tipo de feed de actualizaciones del viaje](./trip-updates).
+Actualización en tiempo real del progreso de un vehículo en un viaje. Consulta también el debate general del [tipo de feed de actualizaciones del viaje](./trip-updates).
 
 Según el valor de ScheduleRelationship, TripUpdate puede especificar lo siguiente:
 
@@ -105,7 +106,7 @@ Según el valor de ScheduleRelationship, TripUpdate puede especificar lo siguien
 *   Un viaje que avanza por una ruta, pero que no tiene una programación fija.
 *   Un viaje que se ha agregado o se ha quitado en relación con una programación.
 
-Las actualizaciones pueden ser para eventos de llegada/salida futuros y previstos, o para eventos pasados que ya ocurrieron. En la mayoría de los casos, la información sobre los eventos pasados es un valor medido, por lo tanto, se recomienda que su valor de incertidumbre sea 0\. Aunque puede haber algunos casos en que esto no sea así, por lo que se admiten valores de incertidumbre distintos de 0 para los eventos pasados. Si el valor de incertidumbre de una actualización no es 0, entonces la actualización es una predicción aproximada para un viaje que no se ha completado o la medición no es precisa o la actualización fue una predicción para el pasado que no se ha verificado después de que ocurrió el evento. 
+Las actualizaciones pueden ser para eventos de llegada/salida futuros y previstos, o para eventos pasados que ya ocurrieron. En la mayoría de los casos, la información sobre los eventos pasados es un valor medido, por lo tanto, se recomienda que su valor de incertidumbre sea 0\. Aunque puede haber algunos casos en que esto no sea así, por lo que se admiten valores de incertidumbre distintos de 0 para los eventos pasados. Si el valor de incertidumbre de una actualización no es 0, entonces la actualización es una predicción aproximada para un viaje que no se ha completado o la medición no es precisa o la actualización fue una predicción para el pasado que no se ha verificado después de que ocurrió el evento.
 
 Ten en cuenta que la actualización puede describir un viaje que ya se ha completado. En este caso, es suficiente con proporcionar una actualización para la última parada del viaje. Si el tiempo de llegada para la última parada es en el pasado, el cliente concluirá que todo el viaje es pasado (es posible, aunque inconsecuente, proporcionar también actualizaciones para las paradas anteriores). Esta opción es más relevante para un viaje que se ha completado antes de lo que establecía la programación, pero que según esta, el viaje todavía se está realizando en este momento. Quitar las actualizaciones de este viaje podría hacer que el cliente considere que el viaje todavía se está realizando. Ten en cuenta que el proveedor del feed tiene permitido, aunque no está obligado, a purgar las actualizaciones pasadas (en este caso esto sería útil).
 
@@ -116,7 +117,7 @@ Ten en cuenta que la actualización puede describir un viaje que ya se ha comple
 | **trip** | [TripDescriptor](#TripDescriptor) | obligatorio | El viaje al cual se aplica este mensaje. Puede haber una entidad de TripUpdate, como máximo, para cada instancia de viaje real. Si no hay ninguna, entonces no habrá información de predicciones disponible. *No* significa que el viaje se está realizando de acuerdo con la programación. |
 | **vehicle** | [VehicleDescriptor](#VehicleDescriptor) | opcional | Información adicional sobre el vehículo con el cual se está realizando este viaje. |
 | **stop_time_update** | [StopTimeUpdate](#StopTimeUpdate) | repetido | Las actualizaciones de StopTimes para el viaje (futuras, como las predicciones, y, en algunos casos, pasadas, es decir, aquellas que ya ocurrieron). Las actualizaciones deben ordenarse por secuencia de parada y deben aplicarse a todas las siguientes paradas del viaje hasta la próxima especificada. |
-| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Momento en el que se midió el progreso en tiempo real del vehículo. En tiempo de POSIX (es decir, la cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). |
+| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Momento en el que se midió el progreso en tiempo real del vehículo. En POSIX time (es decir, la cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). |
 
 ## _mensaje_ StopTimeEvent
 
@@ -125,21 +126,21 @@ Información de horarios para un único evento previsto (sea la llegada o la sal
 *   La demora (delay) debe usarse cuando la predicción se realiza con relación a una programación existente en GTFS.
 *   El tiempo (time) debe darse aunque no haya una programación prevista. Si se especifican tanto el tiempo como la demora, el tiempo será prioritario (aunque, por lo general, el tiempo, si se otorga para un viaje programado, debe ser igual al tiempo programado en GTFS + la demora).
 
-La incertidumbre se aplica de la misma forma tanto al tiempo como a la demora. La incertidumbre especifica el error esperado en una demora real (pero ten en cuenta, que todavía no definimos su significado estadístico preciso). Es posible que la incertidumbre sea 0, por ejemplo, para los trenes que funcionan con un control de horarios por computadora.
+La incertidumbre se aplica de la misma forma tanto al tiempo como a la demora. La incertidumbre especifica el error esperado en una demora real (pero ten en cuenta, que todavía no definimos su significado estadístico concreto). Es posible que la incertidumbre sea 0, por ejemplo, para los trenes que funcionan con un control de horarios por computadora.
 
 ### Campos
 
 | _**Nombre del campo**_ | _**Tipo**_ | _**Cardinalidad**_ | _**Descripción**_ |
 |------------------------|------------|--------------------|-------------------|
 | **delay** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | La demora (en segundos) puede ser positiva (significa que el vehículo está retrasado) o negativa (significa que el vehículo está adelantado). Una demora de 0 significa que el vehículo está yendo a tiempo. |
-| **time** | [int64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Evento como tiempo absoluto. En tiempo de POSIX (es decir, la cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). |
+| **time** | [int64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Evento como tiempo absoluto. En POSIX time (es decir, la cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). |
 | **uncertainty** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Si se omite la incertidumbre, se interpreta como desconocida. Para especificar una predicción completamente certera, establece la incertidumbre en 0. |
 
 ## _mensaje_ StopTimeUpdate
 
 La actualización en tiempo real para los eventos de llegada o de salida para una determinada parada de un viaje. Consulta el debate general de las actualizaciones de tiempos de parada en la documentación de [TripDescriptor](#TripDescriptor) y [del tipo de feed de actualizaciones de viaje](./trip-updates).
 
-Las actualizaciones se pueden proporcionar tanto para eventos pasados como futuros. El productor tiene permitido, aunque no está obligado, a desestimar los eventos pasados.
+Las actualizaciones se pueden proporcionar tanto para eventos pasados como futuros. El productor tiene permitido, aunque no está obligado a, desestimar los eventos pasados.
  La actualización está vinculada a una parada específica sea a través de stop_sequence o de stop_id, de manera que uno de estos campos debe definirse, necesariamente.
 
 ### Campos
@@ -178,7 +179,7 @@ Información de posicionamiento en tiempo real para un vehículo dado
 | **current_stop_sequence** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | El índice de la secuencia de parada de la parada actual. El significado de current_stop_sequence (es decir, la parada a la que hace referencia) está determinado por current_status. Si falta el valor en current_status, se asume IN_TRANSIT_TO. |
 | **stop_id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Identifica la parada actual. El valor debe ser el mismo que el de stops.txt en el feed GTFS correspondiente. |
 | **current_status** | [VehicleStopStatus](#VehicleStopStatus) | opcional | El estado exacto del vehículo con respecto a la parada actual. Se ignora si falta el valor en current_stop_sequence. |
-| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Momento en el cual se midió la posición del vehículo. En tiempo de POSIX (es decir, la cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). |
+| **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Momento en el cual se midió la posición del vehículo. En POSIX time (es decir, la cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#CongestionLevel) | opcional |
 
 ## _enum._ VehicleStopStatus
@@ -193,7 +194,7 @@ Información de posicionamiento en tiempo real para un vehículo dado
 
 ## _enum._ CongestionLevel
 
-El nivel de congestión que está afectando al vehículo.
+El nivel de tráfico que está afectando al vehículo.
 
 ### Valores
 
@@ -268,8 +269,8 @@ Un intervalo de tiempo. El intervalo se considera activo `t` si `t` es mayor o i
 
 | _**Nombre del campo**_ | _**Tipo**_ | _**Cardinalidad**_ | _**Descripción**_ |
 |------------------------|------------|--------------------|-------------------|
-| **start** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Hora de inicio, en tiempo de POSIX (es decir, la cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). Si falta esta información, el intervalo comienza con el valor infinito negativo. |
-| **end** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Hora de finalización, en tiempo de POSIX (es decir, la cantidad de segundos desde el 1.° de enero de 1970 00:00:00 UTC). Si falta esta información, el intervalo finaliza con el valor infinito positivo. |
+| **start** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Hora de inicio, en POSIX time (es decir, la cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). Si falta esta información, el intervalo comienza con el valor infinito negativo. |
+| **end** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | opcional | Hora de finalización, en POSIX time (es decir, la cantidad de segundos desde el 1 de enero de 1970 00:00:00 UTC). Si falta esta información, el intervalo finaliza con el valor infinito positivo. |
 
 ## _mensaje_ Position
 
@@ -341,7 +342,7 @@ Un selector para una entidad en un feed GTFS. Los valores de los campos deben co
 
 ## _mensaje_ TranslatedString
 
-Un mensaje internacionalizado que contiene versiones por idioma de un fragmento de texto o una URL. Se seleccionará una de las cadenas de un mensaje. La resolución se realiza de la siguiente manera: si el idioma de la IU coincide con el código de idioma de una traducción, se elije la primera traducción coincidente. Si un idioma de IU predetermiando (por ejemplo, inglés) coincide con el código de idioma de una traducción, se elije la primera traducción coincidente. Si alguna traducción tiene un código de idioma no especificado, se elija esa traducción.
+Un mensaje internacionalizado que contiene versiones por idioma de un fragmento de texto o una URL. Se seleccionará una de las cadenas de un mensaje. La resolución se realiza de la siguiente manera: si el idioma de la UI coincide con el código de idioma de una traducción, se elije la primera traducción coincidente. Si un idioma de UI predetermiando (por ejemplo, inglés) coincide con el código de idioma de una traducción, se elije la primera traducción coincidente. Si alguna traducción tiene un código de idioma no especificado, se elija esa traducción.
 
 ### Campos
 

--- a/gtfs-realtime/spec/es/service-alerts.md
+++ b/gtfs-realtime/spec/es/service-alerts.md
@@ -1,6 +1,6 @@
-Las alertas de servicio te permiten proporcionar actualizaciones cada vez que se produce una interrupción en la red. Las demoras y cancelaciones de viajes individuales a menudo se deben comunicar a través de las [Actualizaciones de viaje](trip-updates.md).
+Las alertas de servicio permiten proporcionar actualizaciones cada vez que se produce una interrupción en la red. Las demoras y cancelaciones de viajes individuales a menudo se deben comunicar a través de las [Actualizaciones de viaje](trip-updates.md).
 
-Puedes proporcionar la siguiente información:
+Se puede proporcionar la siguiente información:
 
 *   la URL del sitio en el que se ofrecen más detalles acerca de la alerta,
 *   el texto del encabezado a modo de resumen de la alerta,
@@ -8,25 +8,25 @@ Puedes proporcionar la siguiente información:
 
 ### Período
 
-La alerta aparecerá cuando corresponda en el transcurso del período establecido. Este período debe cubrir en su totalidad el lapso en el que el pasajero necesita la alerta.
+La alerta aparecerá en el momento apropiado, dentro del período establecido. Este período debe cubrir en su totalidad el lapso en el que el pasajero necesita la alerta.
 
-Si no se establece ningún período, mostraremos la alerta el tiempo que esta se encuentre en el feed. Si se establecen varios períodos, mostraremos la alerta durante todos ellos.
+Si no se establece ningún período, mostraremos la alerta durante el tiempo en que esta se encuentre en el feed. Si se establecen varios períodos, mostraremos la alerta durante todos ellos.
 
 ### Selector de entidad
 
-El selector de entidad te permite especificar exactamente qué partes de la red afecta una alerta, a fin de que le podamos mostrar al usuario solo las alertas más adecuadas. Puedes incluir varios selectores de entidad en el caso de las alertas que afectan muchas entidades.
+El selector de entidad permite especificar exactamente a qué partes de la red afecta una alerta, con el fin de poder mostrar al usuario sólo las alertas más adecuadas. Varios selectores de entidad pueden ser incluidos, para los casos en los que las alertas afecten a muchas entidades.
 
-Las entidades se seleccionan a través de los identificadores de la especificación GTFS y puedes elegir cualquiera de los siguientes:
+Las entidades se seleccionan a través de los identificadores de la especificación GTFS, pudiéndose elegir entre:
 
 *   Empresa: afecta toda la red.
 *   Ruta: afecta toda la ruta.
-*   Tipo de ruta: afecta cualquier ruta del tipo seleccionado; p. ej., todos los metros.
+*   Tipo de ruta: afecta cualquier ruta del tipo seleccionado; p. ej.: todos los metros.
 *   Viaje: afecta un viaje en particular.
 *   Parada: afecta una parada en particular.
 
 ### Causa
 
-¿Cuál es la causa de esta alerta? Puedes especificar cualquiera de las siguientes:
+¿Cuál es la causa de esta alerta? Se pueden especificar cualquiera de las siguientes:
 
 *   causa desconocida,
 *   otra causa (que no se ve representada por ninguna de estas opciones),
@@ -41,9 +41,9 @@ Las entidades se seleccionan a través de los identificadores de la especificaci
 *   actividad policial,
 *   emergencia médica.
 
-### Efecto
+### Consecuencia
 
-¿Qué efecto tiene este problema en la entidad seleccionada? Puedes especificar cualquiera de los siguientes:
+¿Qué conscuencia tiene este problema para la entidad seleccionada? Se pueden especificar cualquiera de las siguientes:
 
 *   sin servicio,
 *   servicio reducido,

--- a/gtfs-realtime/spec/es/trip-updates.md
+++ b/gtfs-realtime/spec/es/trip-updates.md
@@ -1,22 +1,22 @@
-Las actualizaciones de viaje representan fluctuaciones en el horario. Esperamos recibir actualizaciones de viaje para todos los viajes que has programado, que sean aptos para tiempo real. Estas actualizaciones brindarían un horario de llegada o salida previsto para las paradas a lo largo de la ruta. Las actualizaciones de viaje también pueden prever escenarios más complejos en los cuales se cancelen o agreguen viajes al programa, o incluso se redirijan.
+Las actualizaciones de viaje representan fluctuaciones en el horario. Se espera recibirlas de todos los viajes programados que puedan proporcionarlas en tiempo real. Estas actualizaciones brindarían un horario de llegada o salida previsto para las paradas a lo largo de la ruta. Las actualizaciones de viaje también pueden prever escenarios más complejos en los cuales se cancelen o agreguen viajes al programa, o incluso se redirijan.
 
 **Recordatorio:** En [GTFS](https://developers.google.com/transit/gtfs/), un viaje es una secuencia de dos o más paradas que tienen lugar a una hora específica.
 
-Debe haber **como máximo** una actualización de viaje para cada viaje programado. En caso de que no haya ninguna actualización de viaje para un viaje programado, se concluirá que no hay datos en tiempo real disponibles para el viaje. El consumidor de datos **no** debe asumir que el viaje se está realizando a horario.
+Debe haber **como máximo** una actualización de viaje para cada viaje programado. En caso de no ser así, se concluirá que no hay datos en tiempo real disponibles para dicho viaje. El consumidor de datos **no** debe asumir que el viaje se está realizando de manera puntual.
 
 ## Actualizaciones de horario de paradas
 
-Una actualización de viaje comprende una o más actualizaciones a los horarios de parada del vehículo, que se conocen como [StopTimeUpdates](reference.md#StopTimeUpdate). Pueden proporcionarse para horarios de paradas pasados y futuros. Tienes permitido brindar horarios de parada pasados, pero no es obligatorio que los brindes. Cuando lo hagas, ten en cuenta que no debes proporcionar una actualización pasada si se refiere a un viaje todavía no programado para haber terminado (es decir, que finalizó antes de lo programado), ya que, de lo contrario, se concluirá que no hay actualización de ese viaje.
+Una actualización de viaje comprende una o más actualizaciones de los horarios de parada del vehículo, conocidas como [StopTimeUpdates](reference.md#StopTimeUpdate). Pueden proporcionarse para horarios de paradas pasados y futuros. Se permite brindar horarios de parada pasados, pero no es obligatorio hacerlo. En el caso de que se haga, ten en cuenta que no se debe proporcionar una actualización pasada si se refiere a un viaje todavía no programado para haber terminado (es decir, que finalizó antes de lo programado), ya que, de lo contrario, se concluirá que no hay actualización de ese viaje.
 
-Cada [StopTimeUpdate](reference.md#StopTimeUpdate) está vinculada a una parada. Normalmente, esto se puede hacer usando un GTFS stop_sequence o un GTFS stop_id. Sin embargo, en caso de que estés suministrando una actualización para un viaje sin un trip_id de GTFS, debes especificar el stop_id ya que stop_sequence no tiene valor. El stop_id todavía debe hacer referencia a un stop_id en GTFS.
+Cada [StopTimeUpdate](reference.md#StopTimeUpdate) está vinculada a una parada. Normalmente esto se puede hacer usando un GTFS stop_sequence o un GTFS stop_id. Sin embargo, en caso de que estés suministrando una actualización para un viaje sin un trip_id de GTFS, debes especificar el stop_id, ya que stop_sequence no tiene valor. El stop_id todavía debe hacer referencia a un stop_id en GTFS.
 
-La actualización puede proporcionar un horario exacto para la **llegada** o la **salida** en una parada en [StopTimeUpdates](reference.md#StopTimeUpdate) mediante [StopTimeEvent](reference.md#StopTimeUpdate). Esto debe contener un **horario** absoluto o un **retraso** (es decir, una compensación desde el horario programado en segundos). El retraso solo se puede utilizar en caso de que la actualización de viaje se refiera a un viaje de GTFS programado, en contraposición con un viaje basado en la frecuencia. En este caso, el horario debe ser igual al horario programado + el retraso. También debes especificar la **incertidumbre** de la predicción junto con [StopTimeEvent](reference.md#StopTimeUpdate), que se analiza más detalladamente en la sección [Incertidumbre](#Incertidumbre) más abajo en la página.
+La actualización puede proporcionar un horario exacto para la **llegada** o la **salida** en una parada en [StopTimeUpdates](reference.md#StopTimeUpdate) mediante [StopTimeEvent](reference.md#StopTimeUpdate). Este debe contener un **horario** absoluto o un **retraso** (es decir, una compensación desde el horario programado en segundos). El retraso solo se puede utilizar en caso de que la actualización de viaje se refiera a un viaje de GTFS programado, en contraposición con un viaje basado en la frecuencia. En este caso, el horario debe ser igual al horario programado + el retraso. También se debe especificar la **incertidumbre** de la predicción junto con [StopTimeEvent](reference.md#StopTimeUpdate), que se analiza más detalladamente más abajo, en la sección [Incertidumbre](#Incertidumbre).
 
-Para cada [StopTimeUpdate](reference.md#StopTimeUpdate), la relación de programación predeterminada es **programada**. (Ten en cuenta que es diferente de la relación de programación para el viaje). Puedes cambiarla a **omitida** si la parada no se va a utilizar o a **sin datos** si solo tienes datos en tiempo real para parte del viaje.
+Para cada [StopTimeUpdate](reference.md#StopTimeUpdate), la relación de programación predeterminada es **programada**. (Ten en cuenta que ésta es diferente a la relación de programación para el viaje). Puedes cambiarla a **omitida** si la parada no se va a utilizar o a **sin datos** si solo tienes datos en tiempo real para parte del viaje.
 
 **Las actualizaciones se deben clasificar por stop_sequence** (o stop_id, en el orden en que tienen lugar en el viaje).
 
-Si faltan una o más paradas a lo largo del viaje, la actualización se propaga a todas las paradas subsiguientes. Esto significa que, en caso de no haber otra información, al actualizar un horario de parada para una cierta parada, se cambiarán todas las paradas subsiguientes.
+Si faltan una o más paradas a lo largo del viaje, la actualización se propaga a todas las paradas subsiguientes. Esto significa que, en caso de no haber otra información, al actualizar un horario de parada para una cierta parada se cambiarán todas las paradas subsiguientes.
 
 **Ejemplo 1**
 
@@ -26,9 +26,9 @@ Para un viaje con 20 paradas, una [StopTimeUpdate](reference.md#StopTimeUpdate) 
 
 Para la misma instancia de viaje, se proporcionan tres [StopTimeUpdates](reference.md#StopTimeUpdate):
 
-*   retraso de 300 segundos para la stop_sequence 3
-*   retraso de 60 segundos para la stop_sequence 8
-*   retraso de duración no especificada para la stop_sequence 10
+*   retraso de 300 segundos para la stop_sequence 3.
+*   retraso de 60 segundos para la stop_sequence 8.
+*   retraso de duración no especificada para la stop_sequence 10.
 
 Esto se interpretará como:
 
@@ -38,19 +38,19 @@ Esto se interpretará como:
 
 ### Descriptor de viajes
 
-La información suministrada por el descriptor de viajes depende de la relación de programación del viaje que estás actualizando. Hay una cantidad de opciones que puedes configurar:
+La información suministrada por el descriptor de viajes depende de la relación de programación del viaje que estás actualizando. Hay varias opciones que puedes configurar:
 
 | _**Valor**_ | _**Comentario**_ |
 |-------------|------------------|
 | **Programado** | Este viaje se está ejecutando de acuerdo con un programa de GTFS o se asemeja lo suficiente como para seguir estando asociado a él. |
-| **Agregado** | Este viaje no estaba programado y se ha agregado. Por ejemplo, para hacer frente a la demanda o reemplazar un vehículo averiado. |
-| **Sin programar** | Este viaje se está ejecutando y nunca se asocia con un programa. Por ejemplo, si no hay programa y los autobuses operan en un servicio de traslados. |
-| **Cancelado** | Este viaje se programó pero ahora se eliminó. |
+| **Agregado** | Este viaje no estaba programado y se ha agregado. Por ejemplo, para satisfacer la demanda o reemplazar un vehículo averiado. |
+| **Sin programar** | Este viaje está teniendo lugar, pero nunca está asociado con horario alguno. Por ejemplo, si no hay programa y los autobuses operan en un servicio de traslados. |
+| **Cancelado** | Este viaje se programó pero ahora está eliminado. |
 
-En la mayoría de los casos, debes proporcionar el trip_id del viaje programado en GTFS con el que se relaciona esta actualización. En caso de que no puedas vincular esta actualización con un viaje en GTFS, puedes brindar un route_id de GTFS, y una fecha y hora de inicio para el viaje. Generalmente, este es el caso de los viajes agregados, sin programar y de algunos tipos de viajes de reemplazo.
+En la mayoría de los casos, se debe proporcionar el trip_id del viaje programado en GTFS con el que se relaciona esta actualización. En caso de que no se pueda vincular esta actualización con un viaje en GTFS, se puede brindar un route_id de GTFS, y una fecha y hora de inicio para el viaje. Generalmente, este es el caso de los viajes agregados, los que están sin programar y de algunos tipos de viajes de reemplazo.
 
 ## Incertidumbre
 
-La incertidumbre se aplica tanto al horario como al valor de retraso de una [StopTimeUpdate](reference.md#StopTimeUpdate). La incertidumbre especifica, en términos generales, el error esperado en retraso verdadero como un entero en segundos (pero ten en cuenta que, el significado estadístico preciso todavía no está definido). Es posible que la incertidumbre sea 0, por ejemplo, para los trenes conducidos bajo control de horarios por computadora.
+La incertidumbre se aplica tanto al horario como al valor de retraso de una [StopTimeUpdate](reference.md#StopTimeUpdate). La incertidumbre especifica, en términos generales, el error esperado en el retraso real como un entero en segundos (pero ten en cuenta que el significado estadístico concreto todavía no está definido). Es posible que la incertidumbre sea 0, por ejemplo, para los trenes conducidos bajo control de horarios por computadora.
 
-Como ejemplo, un autobús de larga distancia que tiene un retraso estimado de 15 minutos y llega a su siguiente parada con una ventana de error de 4 minutos (es decir, +2/-2 minutos) tendrá un valor de Incertidumbre de 240.
+Por ejemplo, un autobús de larga distancia que tiene un retraso estimado de 15 minutos y llega a su siguiente parada con una ventana de error de 4 minutos (es decir, +2/-2 minutos) tendrá una incertidumbre de 240.

--- a/gtfs-realtime/spec/es/vehicle-positions.md
+++ b/gtfs-realtime/spec/es/vehicle-positions.md
@@ -1,36 +1,50 @@
-La posición del vehículo se utiliza para proporcionar información generada automáticamente sobre la ubicación de un vehículo, como de un dispositivo GPS a bordo. Se debe proporcionar una sola posición del vehículo para cada vehículo que puede proporcionarla.
+La posición del vehículo se utiliza para proporcionar información generada automáticamente sobre la ubicación del mismo, como la generada por un GPS a bordo. Se debe proporcionar una sola posición por cada vehículo que pueda hacerlo.
 
-El viaje que el vehículo está realizando actualmente se debe proporcionar a través de un [descriptor de viaje](reference.md#VehicleDescriptor). También puedes proporcionar un [descriptor de vehículo](reference.md#VehicleDescriptor) que especifique un vehículo físico preciso sobre el cual estás proporcionando actualizaciones. La documentación se proporciona a continuación.
+El viaje que el vehículo está realizando actualmente se debe proporcionar a través de un [descriptor de viaje](reference.md#VehicleDescriptor). También se puede proporcionar un [descriptor de vehículo](reference.md#VehicleDescriptor) que especifique un vehículo físico concreto sobre el cual estás proporcionando actualizaciones. La documentación se proporciona más abajo.
 
-Se puede proporcionar una **marca de tiempo** que indique el momento en el que se tomó la lectura de la posición. Ten en cuenta que esto es diferente de la marca de tiempo en el encabezado del feed, que es el tiempo en el que el servidor generó este mensaje.
+Se puede proporcionar una **marca de tiempo** que indique el momento en el que se tomó la lectura de la posición. Hay que tener en cuenta que esta es diferente de la marca de tiempo en el encabezado del feed, que es el tiempo en el que el servidor generó este mensaje.
 
-También se puede proporcionar un **paso actual** (ya sea como stop_sequence o stop_id). Esto es una referencia a la parada a la que el vehículo se está dirigiendo o en la que ya se detuvo.
+También se puede proporcionar un **paso actual** (ya sea como stop_sequence o stop_id). Este es una referencia a la parada a la que el vehículo se está dirigiendo o en la que ya se detuvo.
 
 ## Posición
 
-La posición contiene los datos de ubicación dentro de Posición del vehículo. Los campos de latitud y longitud son obligatorios; los demás campos son opcionales. Estos tipos de datos son:
+La posición contiene los datos de ubicación (Vehicle Position) del vehículo. Los campos de latitud y longitud son obligatorios; los demás campos son opcionales. Estos tipos de datos son:
 
 *   **Latitud**: grados Norte, en el sistema de coordenadas WGS-84.
 *   **Longitud**: grados Este, en el sistema de coordenadas WGS-84.
-*   **Rumbo**: la dirección en la que el vehículo se orienta.
+*   **Rumbo**: la dirección hacia la que el vehículo está orientado.
 *   **Odómetro**: la distancia que el vehículo ha recorrido.
 *   **Velocidad**: velocidad instantánea medida por el vehículo, en metros por segundo.
 
-## Nivel de congestión
+## Nivel de tráfico
 
-La posición del vehículo también permite que la empresa especifique el nivel de congestión que el vehículo está experimentando en el momento. La congestión se puede clasificar en las siguientes categorías:
+La posición del vehículo también permite que la empresa especifique el nivel de tráfico que el vehículo está experimentando en el instante actual. El tráfico se puede clasificar en las siguientes categorías:
 
-*   Nivel de congestión desconocido
-*   Tráfico fluido
-*   Tráfico intermitente
-*   Congestión
-*   Congestión grave
+*   Nivel de tráfico desconocido.
+*   Tráfico fluido.
+*   Tráfico intermitente.
+*   Atasco.
+*   Atrasco grave.
 
-A la empresa le corresponde clasificar lo que clasificas como cada tipo de congestión. Nuestra orientación es que la congestión grave solo se utiliza en situaciones en las que el tráfico está tan congestionado que las personas están abandonando sus vehículos.
+A la empresa le corresponde interpretar nuestra ponderación del tráfico. Desde nuestra perspectiva, la congestión grave solo se utilizaría en situaciones en las que el tráfico está tan congestionado que las personas están abandonando sus vehículos.
 
-## VehicleStopStatus
+## Grado de ocupación del vehículo
 
-El estado de parada del vehículo le da más significado al estado de un vehículo en relación con una parada a la que se está aproximando o en la que ya está. Se puede ajustar a cualquiera de estos valores.
+La posición del vehículo permite a la empresa especificar el grado de ocupación del vehículo, que puede ser clasificado en la siguientes categorías:
+
+*   Vacío.
+*   Muchos asientos libres.
+*   Pocos asientos libres.
+*   Sitio sólo de pie.
+*   Sitio sólo de pie y apretados.
+*   Lleno.
+*   No admite más pasajeros.
+
+Este campo todavía es **experimental** y está sujeto a cambios. Podría pasar a adoptarse formalmente más adelante.
+
+## Estado de parada del vehículo
+
+El estado de parada del vehículo está más relacionado con el estado de una parada a la que se está aproximando o en la que ya está. Se puede ajustar a cualquiera de estos valores.
 
 *   **Llegando a**: el vehículo está a punto de llegar a la parada indicada.
 *   **Detenido en**: el vehículo está detenido en la parada indicada.
@@ -38,8 +52,8 @@ El estado de parada del vehículo le da más significado al estado de un vehícu
 
 ## Descriptor de vehículo
 
-El descriptor de vehículo describe un vehículo físico preciso y puede contener cualquiera de los siguientes atributos:
+El descriptor de vehículo describe un vehículo físico concreto y puede contener cualquiera de los siguientes atributos:
 
 *   **ID**: sistema interno de identificación del vehículo. Debe ser único para el vehículo.
-*   **Etiqueta**: una etiqueta visible para el usuario, por ejemplo el nombre de un tren.
-*   **Placa**: la placa real del vehículo.
+*   **Identificador**: un identificador visible para el usuario, por ejemplo el nombre de un tren.
+*   **Matrícula**: la matrícula real del vehículo.


### PR DESCRIPTION
Fix a number of translation inaccuracies.
Add Occupancy status (missing in the Spanish version of vehicle-positions.md).
Add a missing paragraph to the English version of reference.md.

Resolves #54.