### PR TITLE
Remove requirement for stop_time_update arrival AND departure for SCHEDULED trips

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -160,7 +160,7 @@ The relation between this StopTime and the static schedule.
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| **SCHEDULED** | The vehicle is proceeding in accordance with its static schedule of stops, although not necessarily according to the times of the schedule. This is the **default** behavior. At least one of arrival and departure must be provided. If the schedule for this stop contains both arrival and departure times then so must this update. |
+| **SCHEDULED** | The vehicle is proceeding in accordance with its static schedule of stops, although not necessarily according to the times of the schedule. This is the **default** behavior. At least one of arrival and departure must be provided. |
 | **SKIPPED** | The stop is skipped, i.e., the vehicle will not stop at this stop. Arrival and departure are optional. |
 | **NO_DATA** | No data is given for this stop. It indicates that there is no realtime information available. When set NO_DATA is propagated through subsequent stops so this is the recommended way of specifying from which stop you do not have realtime information. When NO_DATA is set neither arrival nor departure should be supplied. |
 


### PR DESCRIPTION
The following wording for `stop_time_updates` that have `schedule_relationship` of `SCHEDULED` (or no `schedule_relationship` - `SCHEDULED` is default):

> If the schedule for this stop contains both arrival and departure times then so must this update

...is problematic from two perspectives:

1. **GTFS requires both `arrival_time` and `departure_time` in `stop_times.txt` to be populated** - Looking at https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt, it says:

    >*If you don't have separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time*.... If this stop is not a timepoint, use either an empty string value for the arrival_time field or provide an interpolated time...Provide arrival times for all stops that are time points...

    `departure_time` has similar text.

    So, `arrival_time` and `departure_time` should always be populated, which means that the above wording *always* applies to `stop_time_update` `arrival` and `departure` for `SCHEDULED` (normal) trips.

2. **There are valid cases where an `arrival` prediction may not exist, but a `departure` does, and vice versa** - For example, for the first stop in a trip, there may not be a rider-facing prediction for when the bus will arrive at that stop, but there is for when it will depart.  And, vice versa for the last stop in the trip.

To fix this, I'm proposing removing the following text that specifies that both arrival and departure must be populated, which will clarify that providers are allowed to provide only one of the two:

> If the schedule for this stop contains both arrival and departure times then so must this update

This proposal was announced on GTFS-rt Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/hHWOJBMyDws.

**EDIT October 30th 2017**

Reviewing the spec, elsewhere it's clear that arrival *OR* departure can be provided.

[Stop Time Updates](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md#stop-time-updates) narrative section says:

>The update can provide a exact timing for arrival and/or departure at a stop in StopTimeUpdates using StopTimeEvent.

From [StopTimeUpdate](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate), for `arrival` and `departure`:

>If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty

The text I'm proposing to eliminate clearly conflicts with both of these, and is likely left over from an early version of the spec and Google's initial implementation.