### PR TITLE
Add missing links in the community page

### DIFF
--- a/gtfs/spec/en/community.md
+++ b/gtfs/spec/en/community.md
@@ -4,14 +4,14 @@
 
 There are a number of mailing lists that can be good resources when you have questions about public transit data, software, formats like GTFS and GTFS-realtime, and other issues:
 
-* transitfeed: discussion of the open-source transitfeed project, as well of discussion of the GTFS specification and associated tools.
-* gtfs-realtime: discussion of the GTFS-realtime specification.
-* gtfs-changes: discussion of proposal for extending the GTFS specification, as outlined in the GTFS Changes document.
-* transit-developers: general transit developer discussions. Many transit agencies also have their own developer mailing lists specific to the agency. For example:
-  * NYC MTA
-  * Portland, OR
-  * BART - San Francisco, CA
-  * MassDOT
+* [transitfeed](https://groups.google.com/group/transitfeed): discussion of the open-source [transitfeed](https://groups.google.com/group/transitfeed) project, as well of discussion of the GTFS specification and associated tools.
+* [gtfs-realtime](https://groups.google.com/group/gtfs-realtime): discussion of the [GTFS-realtime specification](https://github.com/google/transit/tree/master/gtfs-realtime).
+* [gtfs-changes](https://groups.google.com/group/gtfs-changes): discussion of proposal for extending the GTFS specification, as outlined in the [GTFS Changes document](https://github.com/google/transit/blob/master/gtfs/CHANGES.md).
+* [transit-developers](https://groups.google.com/group/transit-developers): general transit developer discussions. Many transit agencies also have their own developer mailing lists specific to the agency. For example:
+  * [NYC MTA](https://groups.google.com/group/mtadeveloperresources)
+  * [Portland, OR](https://groups.google.com/group/transit-developers-pdx)
+  * [BART - San Francisco, CA](https://groups.google.com/group/bart-developers)
+  * [MassDOT](https://groups.google.com/group/massdotdevelopers)
 
 Check with your local transit agency to see if they have a mailing list of their own.
 


### PR DESCRIPTION
A bunch of links are missing from the community page - I added them in.

This change does not alter the spec.