### PR TITLE
fix gtfs_realtime_version in FeedHeader

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -52,7 +52,7 @@ message FeedMessage {
 message FeedHeader {
   // Version of the feed specification.
   // The current version is 2.0.
-  required string gtfs_realtime_version = 2;
+  required string gtfs_realtime_version = 1;
 
   // Determines whether the current fetch is incremental.  Currently,
   // DIFFERENTIAL mode is unsupported and behavior is unspecified for feeds


### PR DESCRIPTION
in gtfs-realtime/proto/gtfs-realtime.proto the FeedHeader message was misconfigured. gtfs_realtime_version was set = to 2 (the version number) instead of 1 (the field number)