### PR TITLE
Update wheelchair_boarding to include assistance

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -115,14 +115,17 @@ File: **Required**
 |   |  | * **0** (or empty) - indicates that there is no accessibility information for the stop |  |  |
 |   |  | * **1** - indicates that at least some vehicles at this stop can be boarded by a rider in a wheelchair |  |  |
 |   |  | * **2** - wheelchair boarding is not possible at this stop |  |  |
+|   |  | * **3** - wheelchair boarding is possible at this stop, but only with additional assistance. For example, a manual ramp needs to be provided. |  |  |
 |   |  | When a stop is part of a larger station complex, as indicated by a stop with a **parent_station** value, the stop's **wheelchair_boarding** field has the following additional semantics: |  |  |
 |   |  | * **0** (or empty) - the stop will inherit its **wheelchair_boarding** value from the parent station, if specified in the parent |  |  |
 |   |  | * **1** - there exists some accessible path from outside the station to the specific stop / platform |  |  |
 |   |  | * **2** - there exists no accessible path from outside the station to the specific stop / platform |  |  |
+|   |  | * **3** - there exists some accessible path from outside the station to the specific stop / platform, but only with assistance. |  |  |
 |   |  | For station entrances, the **wheelchair_boarding** field has the following additional semantics: |  |  |
 |   |  | * **0** (or empty) - the station entrance will inherit its **wheelchair_boarding** value from the parent station, if specified in the parent |  |  |
 |   |  | * **1** - the station entrance is wheelchair accessible (e.g. an elevator is available to platforms if they are not at-grade)  |  |  |
 |   |  | * **2** - there exists no accessible path from the entrance to station platforms |  |  |
+|   |  | * **3** -  the station entrance is wheelchair accessible but only with assistance (e.g. a stair climber is necessary) |  |  |
 
 ### routes.txt
 


### PR DESCRIPTION
I’d like to propose an additional value in the wheelchair_boarding field: 3. 3 would denote that the path/route to the station, stop or vehicle is partially accessible, but requires additional support. 

This typically means a user can travel from the street to the platform, or from the platform to the train, but not from the street to the train, unless they solicit help from staff or someone else. This would differentiate the value from 1, which would become representative of a route that is accessible without additional support. For example, London’s TfL would map their “step-free to platform” field to this enum, which would cover the entire London Overground stations. Wheelchair-users need to call a staff hotline to get someone to help with a ramp to get on or off the train. Most of the Tokyo overground stations would also be “step-free to platform”.

This field would be valid for both trips.txt and stops.txt.