### PR TITLE
Add file linked_datasets.txt containing the Trip Updates, Vehicle Positions and Service Alerts URLs

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -22,6 +22,7 @@ This document explains the types of files that comprise a GTFS transit feed and 
     -   [shapes.txt](#shapestxt)
     -   [frequencies.txt](#frequenciestxt)
     -   [transfers.txt](#transferstxt)
+    -   [linked_datasets.txt](#linkeddatasetstxt)
     -   [feed\_info.txt](#feed_infotxt)
 
 ## Term Definitions

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -422,7 +422,7 @@ File: **Optional**
 
 |  Field Name | Required | Details |
 |  ------ | ------ | ------ |
-|  url | **Required** | The **url** fields contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
+|  url | **Required** | The **url** field contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
 |  trip_updates | **Required** | The **trip_updates** field indicates whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate). Valid values for this field are: |
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
@@ -432,6 +432,13 @@ File: **Optional**
 |  service_alerts | **Required** | The **service_alerts** field indicates whether the dataset at this URL may contain [an `Alert` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert). Valid values for this field are: |
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
+|  authentication_type | **Required** | The **authentication_type** field defines the type of authentication required to access the URL. Valid values for this field are: |
+|   |  | * **0** or **(empty)** - No authentication required. |
+|   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more informations. |
+|   |  | * **2** - The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL. Please visit URL in `authentication_info_url` for more informations. |
+|  authentication_info_url | **Optional** | If an authentication is required, the **authentication_info_url** field contains an URL to a human readable page describing how the authentication should be done and how potential credentials can be created. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. This field is required for `authentication_type` `1` or above. |
+|  api_key_parameter_name | **Optional** | The **authentication_type** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `1`. |
+
 
 ### feed_info.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -422,7 +422,7 @@ File: **Optional**
 
 |  Field Name | Required | Details |
 |  ------ | ------ | ------ |
-|  url | **Required** | The **url** field contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
+|  url | **Required** | The **url** field contains the URL to the linked dataset. The value must be a fully qualified URL that includes a scheme such as **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
 |  trip_updates | **Required** | The **trip_updates** field indicates whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate). Valid values for this field are: |
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -427,11 +427,11 @@ File: **Optional**
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
 |  vehicle_positions | **Required** | The **vehicle_positions** field indicates whether the dataset at this URL may contain [a `VehiclePosition` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicleposition). Valid values for this field are: |
-|   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
-|   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
+|   |  | * **0** - The dataset at this URL doesn't contain VehiclePosition entities. |
+|   |  | * **1** - The dataset at this URL may contain VehiclePosition entities. |
 |  service_alerts | **Required** | The **service_alerts** field indicates whether the dataset at this URL may contain [an `Alert` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert). Valid values for this field are: |
-|   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
-|   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
+|   |  | * **0** - The dataset at this URL doesn't contain Alert entities. |
+|   |  | * **1** - The dataset at this URL may contain Alert entities. |
 |  authentication_type | **Required** | The **authentication_type** field defines the type of authentication required to access the URL. Valid values for this field are: |
 |   |  | * **0** or **(empty)** - No authentication required. |
 |   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more informations. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -50,6 +50,7 @@ This specification defines the following files along with their associated conte
 |  [shapes.txt](#shapestxt)  | Optional | Rules for drawing lines on a map to represent a transit organization's routes. |
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for routes with variable frequency of service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
+|  [linked_datasets.txt](#linkeddatasetstxt)  | Optional | URLs to linked datasets: Trip Update, Vehicle Position and Service Alerts. |
 |  [feed_info.txt](#feed_infotxt)  | Optional | Additional information about the feed itself, including publisher, version, and expiration information. |
 
 ## File Requirements
@@ -413,6 +414,23 @@ Trip planners normally calculate transfer points based on the relative proximity
 |   |  | * **3** - Transfers are not possible between routes at this location. |
 |  min_transfer_time | Optional | When a connection between routes requires an amount of time between arrival and departure (transfer_type=2), the **min_transfer_time** field defines the amount of time that must be available in an itinerary to permit a transfer between routes at these stops. The min_transfer_time must be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route. |
 |   |  | The min_transfer_time value must be entered in seconds, and must be a non-negative integer. |
+
+### linked_datasets.txt
+
+File: **Optional**
+
+|  Field Name | Required | Details |
+|  ------ | ------ | ------ |
+|  url | **Required** | The **url** fields contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to trip_updates fully qualified URL values. |
+|  trip_updates | **Required** | The **trip_updates** field indicates whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate). Valid values for this field are: |
+|   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
+|   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
+|  vehicle_positions | **Required** | The **vehicle_positions** field indicates whether the dataset at this URL may contain [a `VehiclePosition` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicleposition). Valid values for this field are: |
+|   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
+|   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
+|  service_alerts | **Required** | The **service_alerts** field indicates whether the dataset at this URL may contain [an `Alert` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert). Valid values for this field are: |
+|   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
+|   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
 
 ### feed_info.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -51,7 +51,7 @@ This specification defines the following files along with their associated conte
 |  [shapes.txt](#shapestxt)  | Optional | Rules for drawing lines on a map to represent a transit organization's routes. |
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for routes with variable frequency of service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
-|  [linked_datasets.txt](#linkeddatasetstxt)  | Optional | URLs to linked datasets: Trip Update, Vehicle Position and Service Alerts. |
+|  [linked_datasets.txt](#linkeddatasetstxt)  | Optional | URLs to linked datasets: Trip Updates, Vehicle Positions and Service Alerts. |
 |  [feed_info.txt](#feed_infotxt)  | Optional | Additional information about the feed itself, including publisher, version, and expiration information. |
 
 ## File Requirements
@@ -422,7 +422,7 @@ File: **Optional**
 
 |  Field Name | Required | Details |
 |  ------ | ------ | ------ |
-|  url | **Required** | The **url** fields contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to trip_updates fully qualified URL values. |
+|  url | **Required** | The **url** fields contains the URL to the linked dataset. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
 |  trip_updates | **Required** | The **trip_updates** field indicates whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate). Valid values for this field are: |
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -422,7 +422,7 @@ File: **Optional**
 
 |  Field Name | Required | Details |
 |  ------ | ------ | ------ |
-|  url | **Required** | The **url** field contains the URL to the linked dataset. The value must be a fully qualified URL that includes a scheme such as **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. |
+|  url | **Required** | The **url** field contains the URL to the linked dataset. The value must be a fully qualified URL that includes a scheme such as **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values (e.g. https://my.feed.com/trip_updates.pb). |
 |  trip_updates | **Required** | The **trip_updates** field indicates whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate). Valid values for this field are: |
 |   |  | * **0** - The dataset at this URL doesn't contain TripUpdate entities. |
 |   |  | * **1** - The dataset at this URL may contain TripUpdate entities. |
@@ -434,7 +434,7 @@ File: **Optional**
 |   |  | * **1** - The dataset at this URL may contain Alert entities. |
 |  authentication_type | **Required** | The **authentication_type** field defines the type of authentication required to access the URL. Valid values for this field are: |
 |   |  | * **0** or **(empty)** - No authentication required. |
-|   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more informations. |
+|   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more information. |
 |   |  | * **2** - The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL. Please visit URL in `authentication_info_url` for more information. |
 |  authentication_info_url | **Optional** | If authentication is required, the **authentication_info_url** field contains a URL to a human-readable page describing how the authentication should be performed and how credentials can be created. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. This field is required for `authentication_type` `1` or greater. |
 |  api_key_parameter_name | **Optional** | The **api_key_parameter_name** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `2`. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -437,7 +437,7 @@ File: **Optional**
 |   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more informations. |
 |   |  | * **2** - The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL. Please visit URL in `authentication_info_url` for more informations. |
 |  authentication_info_url | **Optional** | If an authentication is required, the **authentication_info_url** field contains an URL to a human readable page describing how the authentication should be done and how potential credentials can be created. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. This field is required for `authentication_type` `1` or above. |
-|  api_key_parameter_name | **Optional** | The **authentication_type** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `1`. |
+|  api_key_parameter_name | **Optional** | The **authentication_type** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `2`. |
 
 
 ### feed_info.txt

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -435,9 +435,9 @@ File: **Optional**
 |  authentication_type | **Required** | The **authentication_type** field defines the type of authentication required to access the URL. Valid values for this field are: |
 |   |  | * **0** or **(empty)** - No authentication required. |
 |   |  | * **1** - Ad-hoc authentication required, visit URL in `authentication_info_url` for more informations. |
-|   |  | * **2** - The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL. Please visit URL in `authentication_info_url` for more informations. |
-|  authentication_info_url | **Optional** | If an authentication is required, the **authentication_info_url** field contains an URL to a human readable page describing how the authentication should be done and how potential credentials can be created. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. This field is required for `authentication_type` `1` or above. |
-|  api_key_parameter_name | **Optional** | The **authentication_type** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `2`. |
+|   |  | * **2** - The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL. Please visit URL in `authentication_info_url` for more information. |
+|  authentication_info_url | **Optional** | If authentication is required, the **authentication_info_url** field contains a URL to a human-readable page describing how the authentication should be performed and how credentials can be created. The value must be a fully qualified URL that includes **http**:// or **https**://, and any special characters in the URL must be correctly escaped. See http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to fully qualified URL values. This field is required for `authentication_type` `1` or greater. |
+|  api_key_parameter_name | **Optional** | The **api_key_parameter_name** field defines the name of the parameter to pass in the URL to provide the API key. This field is required for `authentication_type` `2`. |
 
 
 ### feed_info.txt


### PR DESCRIPTION
#### Current Issue
As data consumer, knowing which producer has real-time and tracking which producer adds real-time is time consuming and requires manual searches. Also, keeping track of the changes of the different real-time URLs (Trip Updates, Vehicle Positions and Service Alerts URLs) is also time consuming and could lead to silent bugs or time-downs.

_[Updated on 2018-08-09 to add discovery]
[Updated on 2018-08-15 14:55 UTC to add the example]
[Updated on 2018-08-27 12:37 UTC to add the fields `authentication_type `, `authentication_info_url` & `api_key_parameter_name `]_

#### Proposal
We can add those real-time URLs in an extra file of the GTFS.

This proposal adds a new file called `linked_datasets.txt`, containing the fields:
- `url` (String, required): A full URL, linking to the other dataset;
- `trip_updates` (Boolean, required): Whether the dataset at this URL may contain [a `TripUpdate` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripupdate).
- `vehicle_positions` (Boolean, required): Whether the dataset at this URL may contain [a `VehiclePosition` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicleposition).
- `service_alerts` (Boolean, required): Whether the dataset at this URL may contain [an `Alert` entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert).
- `authentication_type` (Integer, required): Defines the type of authentication required to access the URL. The allowed values are:
  - 0 or empty: No authentication required.
  - 1: Ad-hoc authentication required, please check on agency website for more.
  - 2: The authentication requires an API key, which should be passed as value of the parameter `api_key_parameter_name` in the URL.
- `authentication_info_url` (String, optional): If an authentication is required, this field contains an URL to a human readable page describing how the authentication should be done and how potential credentials can be created. Required if `authentication_type` is 1 or greater.
- `api_key_parameter_name` (String, optional): Name of the parameter to pass in the URL to provide the API key. Required if `authentication_type` is 2.

Please note: those datasets are only *linked* to the core GTFS, they are not *owned* by it, and therefore the data in `feed_info.txt` doesn't apply to them (e.g. start & end date).

#### Discussion around the naming of the file
TriMet (Ping @mgilligan & @fpurcell) currently uses the extra file `realtime_feeds.txt` with the fields `url`, `trip_updates`, `service_alerts` and `vehicle_positions`.

My current proposal is only different in the naming of the file (`linked_datasets.txt` vs `realtime_feeds.txt`), for two reasons:
- “realtime”: In the future, other URLs will likely be added, and they may not be of “real-time” datasets. Therefore I would avoid setting in stone a limitation which isn’t needed (e.g. ServiceChanges proposal which allow up to 24h changes).
- “Feed” is a misleading word (IMHO) which is currently used in the specification with different meanings depending of the context. It is either a specific dataset (see `feed_info.feed_start_date`) or the set of the different versions of the dataset (see `feed_version` definition). Some open proposal even define “feed” as being the unique and constant source of the different datasets (see feed_id proposal).

For those reasons, I think `linked_datasets.txt` encapsulate unambiguously the content of the new file, without adding any useless limitations for the future.

#### Background
This has already been proposed in 2014 in the GTFS-changes Google Group (see [here](https://groups.google.com/forum/#!topic/gtfs-changes/m-KIwtNKwOg) and [there](https://groups.google.com/forum/#!topic/gtfs-changes/zVjEoNIPr_Y)). TriMet is currently using the 2014 proposal in their production feed.

#### Example
For example, the `linked_datasets.txt` file for Madison Metro Transit (which does not require authentication) would be:
```
url,trip_updates,vehicle_positions,service_alerts,authentication_type
http://transitdata.cityofmadison.com/TripUpdate/TripUpdates.pb,1,0,0,0
http://transitdata.cityofmadison.com/Vehicle/VehiclePositions.pb,0,1,0,0
http://transitdata.cityofmadison.com/Alert/Alerts.pb,0,0,1,0
```
... and for TriMet (which requires an API key as a URL parameter called `appID` for authentication) it would be:
```
url,trip_updates,vehicle_positions,service_alerts,authentication_type,authentication_info_url,api_key_parameter_name
http://developer.trimet.org/ws/V1/TripUpdate/,1,0,0,2,https://developer.trimet.org/GTFS.shtml,appID
http://developer.trimet.org/ws/gtfs/VehiclePositions,0,1,0,2,https://developer.trimet.org/GTFS.shtml,appID
http://developer.trimet.org/ws/V1/FeedSpecAlerts/,0,0,1,2,https://developer.trimet.org/GTFS.shtml,appID
```

... and for Metra in Chicago (which requires ad-hoc authentication not enumerated in our options, in this case via HTTP basic authentication) it would be:
```
url,trip_updates,vehicle_positions,service_alerts,authentication_type,authentication_info_url
https://gtfsapi.metrarail.com/gtfs/raw/tripUpdates.dat,1,0,0,1,https://metrarail.com/developers/metra-gtfs-api
https://gtfsapi.metrarail.com/gtfs/raw/positionUpdates.dat,0,1,0,1,https://metrarail.com/developers/metra-gtfs-api
https://gtfsapi.metrarail.com/gtfs/raw/alerts.dat,0,0,1,1,https://metrarail.com/developers/metra-gtfs-api
```