### PR TITLE
Define rules for propagating delays across trips in same block

### DIFF
--- a/gtfs-realtime/spec/en/trip-updates.md
+++ b/gtfs-realtime/spec/en/trip-updates.md
@@ -25,11 +25,15 @@ For each [StopTimeUpdate](reference.md#StopTimeUpdate), the default schedule rel
 
 If one or more stops are missing along the trip the update is propagated to all subsequent stops. This means that updating a stop time for a certain stop will change all subsequent stops in the absence of any other information.
 
-**Example 1**
+Delay values (including both a [`StopTimeEvent.delay`](reference.md#message-stoptimeevent) as well as delays calculated by applying a [`StopTimeEvent.time`](reference.md#message-stoptimeevent)) to the schedule in [GTFS `stop_times.txt`](/gtfs/spec/en/reference.md#stop_timestxt) greater than or equal to `0` (vehicles running late or on time) must be propagated across trips within the same block (defined by [GTFS trips.txt block_id](/gtfs/spec/en/reference.md#tripstxt)).  If there is a layover in between Trips A and B (e.g., a 5 minute difference between the Trip A final stop `arrival_time` and the Trip B first stop `departure_time`) and no real-time `delay` or `time` information is provided for the Trip B stops, consumers should subtract the layover time from any delay values from Trip A before propagating the delay to Trip B.  This means that consumers will, in the absence of real-time information for Trip B, assume that if the vehicle is running late it will skip it's scheduled layover time and depart on Trip B as soon as it reaches the stop to catch up to the schedule.  If the vehicle is running late on Trip A but plans to hold for the entire scheduled layover time before starting Trip B, producers must represent this by providing [StopTimeUpdates](reference.md#StopTimeUpdate) on Trip B while the vehicle is serving Trip A so riders waiting for Trip B can see that there will be an extended delay. 
+
+Delay values less than `0` (i.e., vehicles running early) must be propagated across trips in the same block if there is no layover between Trip A and Trip B. If there is difference between the Trip A final stop `arrival_time` and the Trip B first stop `departure_time`, then consumers must assume that the vehicle will hold after finishing Trip A and will start Trip B on time. Producers must indicate if a vehicles is departing early on Trip B by explicitly providing a [StopTimeEvent](reference.md#StopTimeEvent) for Trip B while Trip A is being served by the vehicle.
+
+**Example 1 - Simple propagation within trip**
 
 For a trip with 20 stops, a [StopTimeUpdate](reference.md#StopTimeUpdate) with arrival delay and departure delay of 0 ([StopTimeEvents](reference.md#StopTimeEvent)) for stop_sequence of the current stop means that the trip is exactly on time.
 
-**Example 2**
+**Example 2 - Propagating multiple predictions within a trip**
 
 For the same trip instance, three [StopTimeUpdates](reference.md#StopTimeUpdate) are provided:
 
@@ -43,6 +47,138 @@ This will be interpreted as:
 *   stop_sequences 3,4,5,6,7 have delay of 300 seconds.
 *   stop_sequences 8,9 have delay of 60 seconds.
 *   stop_sequences 10,..,20 have unknown delay.
+
+**Example 3 - Propagating delays across trips in same block - No layover**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` are the same.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 300 seconds
+
+**Example 4 - Propagating delays across trips in same block - 5 min layover with matching delay**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 300 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 0 seconds (trip is on time, as the layover time will be entirely skipped)
+
+**Example 5 - Propagating delays across trips in same block - Layover less than delay**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 200 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 100 seconds (trip is still late, but the layover absorbed 200 seconds of the delay)
+
+**Example 6 - Propagating delays across trips in same block - Layover greater than delay**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 400 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 0 seconds (trip is on time, as the layover time will absorb the delay and the vehicle will still have 100 seconds of the scheduled layover time remaining)
+
+**Example 7 - Propagating delays across trips in same block - Trip B delay provided**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip B has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of 300 seconds
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 300 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 300 seconds (layover time will not be skipped because the producer explicitly provided the delay for Trip B)
+
+**Example 8 - Propagating early arrivals across trips in same block - No layover**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of -300 seconds (5 min early)
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` are the same.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of -300 seconds (assume vehicle will *not* hold to re-align with schedule)
+
+**Example 9 - Propagating early arrivals across trips in same block - Layover**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of -300 seconds (5 min early)
+
+Trip B has no [StopTimeUpdates](reference.md#StopTimeUpdate).
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 200 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of 0 seconds, or on time (assumed vehicle will hold to re-align with schedule)
+
+**Example 10 - Propagating early arrivals across trips in same block - Layover, but Trip B delay provided**
+
+Trip A and Trip B belong to the same block (specified in [GTFS trips.txt](/gtfs/spec/en/reference.md#tripstxt) via `block_id`).
+
+Trip A has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of -300 seconds (5 min early)
+
+Trip B has a single [StopTimeUpdates](reference.md#StopTimeUpdate):
+
+*   delay of -300 seconds  (5 min early)
+
+Trip A final stop `arrival_time` and the Trip B first stop `departure_time` differ by 200 seconds.
+
+This will be interpreted as:
+
+* Trip B stop_sequence 1 has a delay of -300 seconds (an explicit Trip B delay always overrides any propagation from a previous trip in the block)
 
 ### Trip Descriptor
 


### PR DESCRIPTION
The GTFS-realtime spec [currently defines](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md#stop-time-updates) how [StopTimeUpdates](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#StopTimeUpdate) (i.e., delays) should be propagated between stops in the same trip.

However, GTFS-rt has remained silent on whether propagation should occur between two trips within the same block.

This proposal defines rules for propagating delays (late, on time, and early) across trips in same block.  It also gives names to all the propagation examples to make it easier to follow the logic in each example.

The primary goal of this proposal is to avoid hiding delays from riders, which can inadvertently happen if propagation across trips in the same block is not implemented.  For example, if Trips A and B are in the same block, and there is a large delay for Trip A, the rider waiting at the first stop of Trip B should see this info in their mobile app before the vehicle completes Trip A.

I've drafted a [Google Drawing](https://docs.google.com/presentation/d/1bLV8QaQkGARX1g1ThdQr9mf7oOCGs3db2VH9TsZ-tgw/edit) to help explain this issue: 

![propagating delays across trips in same block 3](https://user-images.githubusercontent.com/928045/47940181-40613680-dec0-11e8-9e85-2386a946d214.png)

The proposed rules in this pull request are modeled on the behavior currently implemented in [OneBusAway](https://github.com/OneBusAway/onebusaway-application-modules), which has been deployed across a number of cities including New York, Puget Sound (Seattle), San Diego, Tampa, York Region (CA), and Washington, D.C.

Note that these propagation rules only apply in the absence of explicit StopTimeUpdates for Trip B - the producer can always specify the exact prediction to use for any stop by providing a TripUpdate with a StopTimeUpdate referencing that `stop_sequence`.

Please provide feedback!  I'd especially like feedback on the currently proposed rule for vehicles running *early*.  The proposed rule is based on [OneBusAway's behavior](https://github.com/OneBusAway/onebusaway-application-modules/blob/master/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/ArrivalAndDepartureServiceImpl.java#L899), which is:

~~~
  private int propagateScheduleDeviationForwardWithSlack(int scheduleDeviation, int slack) {
    /**
     * If the vehicle is running early and there is slack built into the
     * schedule, we guess that the vehicle will take that opportunity to pause
     * and let the schedule catch back up. If there is no slack, assume we'll
     * continue to run early.
     */
    if (scheduleDeviation < 0) {
      if (slack > 0)
        return 0;
      return scheduleDeviation;
    }
    ...
~~~

This handles the situation when an agency arbitrarily splits a trip into two (e.g., to change headsigns) but there isn't a layover in the schedule, and therefore the bus doesn't hold and continues to run early. If there is a planned break in the schedule, the driver is more likely to hold and wait to depart until the scheduled departure time.

An alternate rule is that vehicles running early never get propagated across trips, but this design risks dropping real-time info in the middle of a passenger-perceived trip when the agency arbitrarily splits a trip in their GTFS.  And, riders would rather know about an early vehicle than miss this information, and as a result miss their bus.  Therefore, IMHO it seems better to err on the side of propagating early vehicle info rather than dropping it.

Related issues:
* Delay propagation across trips in the same block (specifically on time and late) has been discussed and tentatively agreed upon as an upcoming feature in OpenTripPlanner (see [this thread](https://github.com/opentripplanner/OpenTripPlanner/issues/2295#issuecomment-420320336)).

Announced on GTFS-realtime Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/D5taM5vhEJQ.