### PR TITLE
Changed reference.md and service-alerts.md to clarify ambiguity

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -372,7 +372,7 @@ Identification information for the vehicle performing the trip.
 
 ## _message_ EntitySelector
 
-A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, then the matching has to apply to all the given specifiers.
+A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the `AND` operator and the combination of specifiers should match the information in the corresponding GTFS feed.
 
 #### Fields
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -14,7 +14,7 @@ If no time is given, we will display the alert for as long as it is in the feed.
 
 ### Entity Selector
 
-Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user. You may include multiple entity selectors for alerts which affect multiple entities.
+Entity selector allows you specify exactly which parts of the network this alert affects, so that we can display only the most appropriate alerts to the user.
 
 Entities are selected using their GTFS identifiers, and you can select any of the following:
 
@@ -23,6 +23,8 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 *   Route type - affects any route of this type. e.g. all subways.
 *   Trip - affects a particular trip
 *   Stop - affects a particular stop
+
+You may include multiple entity selectors. When multiple entities are selected in one Alert feed entity, they should be interpreted as being joined by the `AND` logical operator. If you would like to join the entities by the `OR` operator, you should include them in separate Alert feed entities.
 
 ### Cause
 


### PR DESCRIPTION
Clarifying ambiguity in Alert.EntitySelector. Problem can be viewed at https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/19