### PR TITLE
Clarify behavior for multiple fields in Alert EntitySelectors

### DIFF
--- a/gtfs-realtime/spec/en/examples/alerts.asciipb
+++ b/gtfs-realtime/spec/en/examples/alerts.asciipb
@@ -30,9 +30,16 @@ entity {
       # agency_id, route_id, route_type, stop_id, trip (see TripDescriptor)
       route_id: "219"
     }
-    # multiple selectors (informed_entity) can be given
+    # multiple selectors (informed_entity) can be included in one alert entity
     informed_entity {
       stop_id: "16230"
+    }
+    # multiple fields can be included in one informed_entity
+    informed_entity {
+      stop_id: "16299"
+      route_id: "100"
+      # This example means route 100 at stop 16299.
+      # This does not apply to any other stop on route 100 and any other route at stop 16299.
     }
 
     # cause of the alert - see gtfs-realtime.proto for valid values

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -372,7 +372,7 @@ Identification information for the vehicle performing the trip.
 
 ## _message_ EntitySelector
 
-A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, then the matching has to apply to all the given specifiers.
+A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed. At least one specifier must be given. If several are given, they should be interpreted as being joined by the logical `AND` operator.  Additionally, the combination of specifiers must match the corresponding information in the GTFS feed.  In other words, in order for an alert to apply to an entity in GTFS it must match all of the provided EntitySelector fields.  For example, an EntitySelector that includes the fields `route_id: "5"` and `route_type: "3"` applies only to the `route_id: "5"` bus - it does not apply to any other routes of `route_type: "3"`.  If a producer wants an alert to apply to `route_id: "5"` as well as `route_type: "3"`, it should provide two separate EntitySelectors, one referencing `route_id: "5"` and another referencing `route_type: "3"`.
 
 #### Fields
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -24,6 +24,10 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 *   Trip - affects a particular trip
 *   Stop - affects a particular stop
 
+You may include more than one of the fields listed above in one `informed_entity`. When multiple fields are included in one `informed_entity`, they should be interpreted as being joined by the `AND` logical operator. In other words, the alert should only be applied in a context that meets all of the fields provided in an `informed_entity`. For example, if `route_id: "1"` and `stop_id: "5"` are both included in one `informed_entity`, then the alert should apply only to route 1 at stop 5.  It should NOT be applied to any other stop on route 1, and it should NOT be applied to any other route at stop 5.
+
+If you would like to represent an alert that affects more than one entity (e.g. an alert for both route 1 and stop 5) , you should add multiple `informed_entity` to your `alert`, with each of them applying to the affected entity (e.g. one `informed_entity` that includes route 1 and another `informed_entity` that includes stop 5).
+
 ### Cause
 
 What is the cause of this alert? You may specify one of the following:


### PR DESCRIPTION
There has been confusion in the past over the expected behavior of the EntitySelector object within Alerts, especially when multiple fields are provided within an EntitySelector (see https://groups.google.com/forum/#!topic/gtfs-realtime/jamsDygrcSk).  In particular, the GTFS-realtime .proto documentation indicates that these fields should be joined as an AND and the alert should only be applied to the entity if it matches all the provided fields. However, the GTFS-realtime documentation is somewhat ambiguous and could be interpreted as joining these fields as an OR - in other words, the alert applies to all entities that match any of the provided fields.

This proposal clarifies the GTFS-realtime documentation to align with the .proto documentation to clearly indicate that when when multiple fields are provided in an EntitySelector, they should be joined as an AND - in other words, in order for an alert to apply to an entity it must match all of the provided EntitySelector fields.

Announced on the GTFS-realtime group at https://groups.google.com/forum/#!topic/gtfs-realtime/GfwvTmAOu1I.