### PR TITLE
Clarify TripUpdate documentation with use of NO_DATA

### DIFF
--- a/gtfs-realtime/spec/en/trip-updates.md
+++ b/gtfs-realtime/spec/en/trip-updates.md
@@ -35,7 +35,7 @@ For the same trip instance, three [StopTimeUpdates](reference.md#StopTimeUpdate)
 
 *   delay of 300 seconds for stop_sequence 3
 *   delay of 60 seconds for stop_sequence 8
-*   delay of unspecified duration for stop_sequence 10
+*   [ScheduleRelationship](/gtfs-realtime/spec/en/reference.md/#enum-schedulerelationship) of `NO_DATA` for stop_sequence 10
 
 This will be interpreted as:
 


### PR DESCRIPTION
The GTFS-realtime spec doesn't define "a delay of unspecified duration", so this patch clarifies how the ScheduleRelationship of `NO_DATA` should be used within StopTimeUpdates to implement this feature.

Announced on the GTFS-realtime Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/kATL9Q7Y1gI.

**EDIT** additional description supplied by @abyrd:

>This PR concerns an example of delay propagation. In this example, two StopTimeUpdates show a vehicle being late by a specific number of minutes. The third StopTimeUpdate is said to have "a delay of unspecified duration", but it's not entirely clear what such a message would look like. "Unspecified delay" must mean both the arrival time and departure time are missing in that StopTimeUpdate. The documentation on arrival and departure times says: "If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED. If schedule_relationship is NO_DATA, arrival and departure must be empty." So, if this third StopTimeUpdate has unspecified delay, the schedule_relationship must be SKIPPED or NO_DATA, so it is indeed clearer to change the example to use a NO_DATA TripUpdate.