### PR TITLE
Define valid GTFS-realtime version numbers

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -51,7 +51,7 @@ message FeedMessage {
 // Metadata about a feed, included in feed messages.
 message FeedHeader {
   // Version of the feed specification.
-  // The current version is 2.0.
+  // The current version is 2.0.  Valid versions are 2.0, 1.0.
   required string gtfs_realtime_version = 1;
 
   // Determines whether the current fetch is incremental.  Currently,

--- a/gtfs-realtime/spec/en/examples/alerts.asciipb
+++ b/gtfs-realtime/spec/en/examples/alerts.asciipb
@@ -1,6 +1,6 @@
 # header information
 header {
-  # version of speed specification. Currently "2.0"
+  # version of speed specification. Currently "2.0". Valid versions are 2.0, 1.0.
   gtfs_realtime_version: "2.0"
 
   # determines whether dataset is incremental or full

--- a/gtfs-realtime/spec/en/examples/trip-updates-full.asciipb
+++ b/gtfs-realtime/spec/en/examples/trip-updates-full.asciipb
@@ -1,6 +1,6 @@
 # header information
 header {
-  # version of speed specification. Currently "2.0"
+  # version of speed specification. Currently "2.0". Valid versions are 2.0, 1.0.
   gtfs_realtime_version: "2.0"
   # determines whether dataset is incremental or full
   incrementality: FULL_DATASET

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -1,6 +1,6 @@
 A GTFS Realtime feed lets transit agencies provide consumers with realtime information about disruptions to their service (stations closed, lines not operating, important delays, etc.) location of their vehicles, and expected arrival times.
 
-Version 2.0 of the feed specification is discussed and documented on this site.
+Version 2.0 of the feed specification is discussed and documented on this site. Valid versions are 2.0, 1.0.
 
 ### Term Definitions
 


### PR DESCRIPTION
`gtfs_realtime_version` is a string in the Protocol Buffer [gtfs-realtime.proto file](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto#L55), and therefore producers can populate this field with a number of different possible values.  Previously, the exact allowed GTFS-realtime version format hasn't been explicitly defined in a single location, and as a result producers have published a variety of interpretations (e.g., 1.0, 1).  

This proposal strictly defines what the allowed GTFS-realtime version numbers are so that consumers can do exact string matching to determine which GTFS-realtime version the producer is publishing and producers have better guidance for the values they should be using.  

Valid versions are defined as `2.0` and `1.0`. The .proto file [currently lists](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto#L54) `2.0` as the version, and [prior to that](https://github.com/google/transit/blob/33c329b0d07e72744de43319f839810a5df0b439/gtfs-realtime/proto/gtfs-realtime.proto#L50) `1.0` was defined. Based on [our analysis](https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/318#issuecomment-445282302), 37 feeds are using `1.0`, 4 are using `2.0` and 4 agencies are using other values, so this aligns with the majority of values currently in use.