### PR TITLE
Add three new optional fields for timestamps in Service Alerts feed: created_timestamp, last_modified_timestamp, closed_timestamp

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -427,6 +427,15 @@ message Alert {
   // Full description for the alert as plain-text. The information in the
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
+  
+  //Time alert is created, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
+  optional uint64 created_timestamp = 12
+  
+  //Time alert is last modified, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
+  optional uint64 last_modified_timestamp = 13
+  
+  //Time alert is closed, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
+  optional uint64 closed_timestamp = 14
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -429,13 +429,13 @@ message Alert {
   optional TranslatedString description_text = 11;
   
   //Time alert is created, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
-  optional uint64 created_timestamp = 12
+  optional uint64 created_timestamp = 12;
   
   //Time alert is last modified, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
-  optional uint64 last_modified_timestamp = 13
+  optional uint64 last_modified_timestamp = 13;
   
   //Time alert is closed, in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
-  optional uint64 closed_timestamp = 14
+  optional uint64 closed_timestamp = 14;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -265,6 +265,9 @@ An alert, indicating some sort of incident in the public transit network.
 | **url** | [TranslatedString](#message-translatedstring) | Optional | One | The URL which provides additional information about the alert. |
 | **header_text** | [TranslatedString](#message-translatedstring) | Required | One | Header for the alert. This plain-text string will be highlighted, for example in boldface. |
 | **description_text** | [TranslatedString](#message-translatedstring) | Required | One | Description for the alert. This plain-text string will be formatted as the body of the alert (or shown on an explicit "expand" request by the user). The information in the description should add to the information of the header. |
+| **created_timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | This timestamp identifies the moment when the alert has been created. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
+| **last_modified_timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | This timestamp identifies the moment when the alert was last modified. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
+| **closed_timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | This timestamp identifies the moment when the alert has been closed. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 
 ## _enum_ Cause
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -5,6 +5,9 @@ You have the option to provide the following:
 *   URL - link to your site explaining more about the alert
 *   Header text - a summary of the alert
 *   Description - a full description of the alert, which will always be shown alongside the header (so should not repeat this information).
+*   Created timestamp - a timestamp denoting the time when the alert was created.
+*   Last modified timestamp - a timestamp denoting the time when the alert was last modified.
+*   Closed timestamp - a timestamp denoting the time when the alert was closed.
 
 ### Time Range
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -5,9 +5,6 @@ You have the option to provide the following:
 *   URL - link to your site explaining more about the alert
 *   Header text - a summary of the alert
 *   Description - a full description of the alert, which will always be shown alongside the header (so should not repeat this information).
-*   Created timestamp - a timestamp denoting the time when the alert was created.
-*   Last modified timestamp - a timestamp denoting the time when the alert was last modified.
-*   Closed timestamp - a timestamp denoting the time when the alert was closed.
 
 ### Time Range
 


### PR DESCRIPTION
This is a proposal to add three new optional fields of type uint64 to the Service Alerts feed: created_timestamp, last_modified_timestamp, closed_timestamp.

See discussion here: https://github.com/google/transit/issues/131

Announced on the GTFS-realtime Google Groups here: https://groups.google.com/forum/#!topic/gtfs-realtime/dipoHhUt6aE