### PR TITLE
Add new optional field SeverityLevel to Service Alerts feed

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -428,10 +428,10 @@ message Alert {
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
   
-  //Severity of this alert.
+  // Severity of this alert.
   enum SeverityLevel {
 	UNKNOWN_SEVERITY = 1;
-	INFORMATIONAL = 2;
+	INFO = 2;
 	WARNING = 3;
 	SEVERE = 4;
   }

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -428,8 +428,8 @@ message Alert {
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
   
-  // Severity of this alert. This field is still experimental, 
-  // and subject to change. It may be formally adopted in the future.
+  // Severity of this alert. 
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   enum SeverityLevel {
 	UNKNOWN_SEVERITY = 1;
 	INFO = 2;

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -427,6 +427,16 @@ message Alert {
   // Full description for the alert as plain-text. The information in the
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
+  
+  //Severity of this alert.
+  enum SeverityLevel {
+	UNKNOWN_SEVERITY = 1;
+	INFORMATIONAL = 2;
+	WARNING = 3;
+	SEVERE = 4;
+  }
+  
+  optional SeverityLevel severity_level = 12 [default = UNKNOWN_SEVERITY];
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -428,7 +428,8 @@ message Alert {
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
   
-  // Severity of this alert.
+  // Severity of this alert. This field is still experimental, 
+  // and subject to change. It may be formally adopted in the future.
   enum SeverityLevel {
 	UNKNOWN_SEVERITY = 1;
 	INFO = 2;

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -66,6 +66,7 @@ Fields labeled as **experimental** are subject to change and not yet formally ad
             *   [Effect](#enum-effect)
             *   [TranslatedString](#message-translatedstring)
                 *   [Translation](#message-translation)
+			*	[SeverityLevel](#enum-severitylevel)
 
 # Elements
 
@@ -265,6 +266,7 @@ An alert, indicating some sort of incident in the public transit network.
 | **url** | [TranslatedString](#message-translatedstring) | Optional | One | The URL which provides additional information about the alert. |
 | **header_text** | [TranslatedString](#message-translatedstring) | Required | One | Header for the alert. This plain-text string will be highlighted, for example in boldface. |
 | **description_text** | [TranslatedString](#message-translatedstring) | Required | One | Description for the alert. This plain-text string will be formatted as the body of the alert (or shown on an explicit "expand" request by the user). The information in the description should add to the information of the header. |
+| **severity_level** | [SeverityLevel](#enum-severitylevel) | Optional | One | Severity of the alert. |
 
 ## _enum_ Cause
 
@@ -304,6 +306,18 @@ The effect of this problem on the affected entity.
 | **OTHER_EFFECT** |
 | **UNKNOWN_EFFECT** |
 | **STOP_MOVED** |
+
+## _enum_ SeverityLevel
+
+The severity of the alert.
+
+#### Values
+| _**Value**_ |
+|-------------|
+| **UNKNOWN_SEVERITY** |
+| **INFORMATIONAL** |
+| **WARNING** |
+| **SEVERE** |
 
 ## _message_ TimeRange
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -66,7 +66,7 @@ Fields labeled as **experimental** are subject to change and not yet formally ad
             *   [Effect](#enum-effect)
             *   [TranslatedString](#message-translatedstring)
                 *   [Translation](#message-translation)
-			*	[SeverityLevel](#enum-severitylevel)
+            *   [SeverityLevel](#enum-severitylevel)
 
 # Elements
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -266,7 +266,7 @@ An alert, indicating some sort of incident in the public transit network.
 | **url** | [TranslatedString](#message-translatedstring) | Optional | One | The URL which provides additional information about the alert. |
 | **header_text** | [TranslatedString](#message-translatedstring) | Required | One | Header for the alert. This plain-text string will be highlighted, for example in boldface. |
 | **description_text** | [TranslatedString](#message-translatedstring) | Required | One | Description for the alert. This plain-text string will be formatted as the body of the alert (or shown on an explicit "expand" request by the user). The information in the description should add to the information of the header. |
-| **severity_level** | [SeverityLevel](#enum-severitylevel) | Optional | One | Severity of the alert. |
+| **severity_level** | [SeverityLevel](#enum-severitylevel) | Optional | One | Severity of the alert.<br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 
 ## _enum_ Cause
 
@@ -311,11 +311,13 @@ The effect of this problem on the affected entity.
 
 The severity of the alert.
 
+**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
+
 #### Values
 | _**Value**_ |
 |-------------|
 | **UNKNOWN_SEVERITY** |
-| **INFORMATIONAL** |
+| **INFO** |
 | **WARNING** |
 | **SEVERE** |
 


### PR DESCRIPTION
This is a proposal to add a new field SeverityLevel to the ServiceAlerts feed. The SeverityLevel field would be optional and comprised of enum values:
- UNKNOWN_SEVERITY
- INFO
- WARNING
- SEVERE

See discussion here: https://github.com/google/transit/issues/133

Announced on the GTFS-realtime Google Groups here: https://groups.google.com/forum/#!topic/gtfs-realtime/t8bpU5gbjDU