### PR TITLE
Add NO_EFFECT effect option for GTFS-realtime service alert

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -415,6 +415,7 @@ message Alert {
     OTHER_EFFECT = 7;
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
+    NO_EFFECT = 10;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -304,6 +304,7 @@ The effect of this problem on the affected entity.
 | **OTHER_EFFECT** |
 | **UNKNOWN_EFFECT** |
 | **STOP_MOVED** |
+| **NO_EFFECT** |
 
 ## _message_ TimeRange
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -58,3 +58,4 @@ What effect does this problem have on the specified entity? You may specify one 
 *   Stop moved
 *   Other effect (not represented by any of these options)
 *   Unknown effect
+*   No effect: The alert provides information to riders but does not affect operations.  Examples include reminding riders of upcoming holiday schedules, advertising public meetings, and soliciting feedback via surveys.

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -54,8 +54,8 @@ What effect does this problem have on the specified entity? You may specify one 
 *   Significant delays (insignificant delays should only be provided through [Trip updates](trip-updates.md)).
 *   Detour
 *   Additional service
-*   Modified service
+*   Modified service: Operations are different from what the rider would normally expect.  An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week.
 *   Stop moved
 *   Other effect (not represented by any of these options)
 *   Unknown effect
-*   No effect: The alert provides information to riders but does not affect operations.  Examples include reminding riders of upcoming holiday schedules, advertising public meetings, and soliciting feedback via surveys.
+*   No effect: The alert provides information to riders but does not affect operations.  Examples include advertising public meetings and soliciting feedback via surveys.


### PR DESCRIPTION
* Some transit agencies are publishing service alerts that don't actually impact the transit network. Examples include reminding riders of ~~upcoming holiday schedules~~, advertising public meetings, and soliciting feedback via surveys (see below examples from HART's feed in Tampa, FL).  **EDIT** - Per discussion in this thread, upcoming holidays should be marked `MODIFIED_SERVICE`

![image](https://user-images.githubusercontent.com/928045/51344431-a2185200-1a66-11e9-9d6d-6ce5b3798178.png)

* This proposal adds a new alert Effect enumeration `NO_EFFECT` so that transit agency can clearly label these types of alerts as not impacting the transit network.  Consumers can then make a choice if they want to surface these types of alerts in their UI.

Announced on the gtfs-realtime Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/AxHtb6qjKtE.