### PR TITLE
StopTimeUpdate additional field: sign_text

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -221,6 +221,9 @@ message TripUpdate {
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
 
+    // Optional text displayed on signs for this trip at the given stop.
+    optional string sign_text = 6;
+
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -178,6 +178,7 @@ The update is linked to a specific stop either through stop_sequence or stop_id,
 | **arrival** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **departure** | [StopTimeEvent](#message-stoptimeevent) | Conditionally required | One | If schedule_relationship is empty or SCHEDULED, either arrival or departure must be provided within a StopTimeUpdate - both fields cannot be empty. arrival and departure may both be empty when schedule_relationship is SKIPPED.  If schedule_relationship is NO_DATA, arrival and departure must be empty. |
 | **schedule_relationship** | [ScheduleRelationship](#enum-schedulerelationship) | Optional | One | The default relationship is SCHEDULED. |
+| **sign_text** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Text to be displayed on a digital sign at the stop for this StopTimeUpdate. Examples: "Now Boarding", "All aboard", "Stopped 3 stops away" |
 
 ## _enum_ ScheduleRelationship
 


### PR DESCRIPTION
Here @mbta, we've had an additional field in our Enhanced JSON TripUpdates feed which may be useful to others: `status`, attached to `StopTimeUpdate`. We use this value to represent text which appears on signs at the given stop/station, in order to provide that data to clients such as our website. 

You can see examples of this field at [North Station](https://www.mbta.com/stops/place-north?tab=departures), where it's used for boarding statuses on the Commuter Rail, like "Now Boarding" and "All aboard". We also use it for [messages](https://www.mbta.com/news/2018-08-27/stopped-train-messaging-begins-august-28-mbta-countdown-clocks) that trains are stopped unexpectedly.

Per some discussions in #109, if this interests other clients we can promote this into our actual Protobuf feed in addition to our JSON feed.

Google group: https://groups.google.com/forum/#!topic/gtfs-realtime/AmaiiCMLbjI