### PR TITLE
Use doubleoctagon for entrances and hexagon for generic nodes

### DIFF
--- a/gtfs/scripts/testdata/au-sydney-entrances.dot
+++ b/gtfs/scripts/testdata/au-sydney-entrances.dot
@@ -22,17 +22,17 @@ digraph D {
       LR_TavHill_P2_S [ label=LR_TavHill_P2_S color=springgreen shape=oval ]
     }
 
-    LR_TavHill_EntranceLiftN [ label="LR_TavHill_EntranceLiftN\nParramatta Road" color=lightcoral shape=triangle ]
+    LR_TavHill_EntranceLiftN [ label="LR_TavHill_EntranceLiftN\nParramatta Road" color=lightcoral shape=doubleoctagon ]
 
-    LR_TavHill_EntranceStairsN [ label="LR_TavHill_EntranceStairsN\nParramatta Road" color=lightcoral shape=triangle ]
+    LR_TavHill_EntranceStairsN [ label="LR_TavHill_EntranceStairsN\nParramatta Road" color=lightcoral shape=doubleoctagon ]
 
-    LR_TavHill_EntranceLiftS [ label="LR_TavHill_EntranceLiftS\nParramatta Road" color=lightcoral shape=triangle ]
+    LR_TavHill_EntranceLiftS [ label="LR_TavHill_EntranceLiftS\nParramatta Road" color=lightcoral shape=doubleoctagon ]
 
-    LR_TavHill_EntranceStairsS [ label="LR_TavHill_EntranceStairsS\nParramatta Road" color=lightcoral shape=triangle ]
+    LR_TavHill_EntranceStairsS [ label="LR_TavHill_EntranceStairsS\nParramatta Road" color=lightcoral shape=doubleoctagon ]
 
-    LR_TavHill_BridgeN [ label=LR_TavHill_BridgeN color=lightgrey shape=diamond ]
+    LR_TavHill_BridgeN [ label=LR_TavHill_BridgeN color=lightgrey shape=hexagon ]
 
-    LR_TavHill_BridgeS [ label=LR_TavHill_BridgeS color=lightgrey shape=diamond ]
+    LR_TavHill_BridgeS [ label=LR_TavHill_BridgeS color=lightgrey shape=hexagon ]
   }
 
 

--- a/gtfs/scripts/visualize_pathways.py
+++ b/gtfs/scripts/visualize_pathways.py
@@ -332,8 +332,8 @@ def location_shape(location_type):
     shapes = {
         LocationType.platform: "box",
         LocationType.station: "polygon",
-        LocationType.entrance: "triangle",
-        LocationType.generic_node: "diamond",
+        LocationType.entrance: "doubleoctagon",
+        LocationType.generic_node: "hexagon",
         LocationType.boarding_area: "oval",
     }
     return shapes.get(location_type, "blue")


### PR DESCRIPTION
The new shapes are more compact and look better on the graph.