### PR TITLE
Add accessibility issue alert effect

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -416,7 +416,7 @@ message Alert {
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
     NO_EFFECT = 10;
-    OUT_OF_SERVICE_ELEVATOR = 11;
+    ACCESSBILITY_ISSUE = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -416,6 +416,7 @@ message Alert {
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
     NO_EFFECT = 10;
+    OUT_OF_SERVICE_ELEVATOR = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -416,7 +416,7 @@ message Alert {
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
     NO_EFFECT = 10;
-    ACCESSBILITY_ISSUE = 11;
+    ACCESSIBILITY_ISSUE = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -309,6 +309,7 @@ The effect of this problem on the affected entity.
 | **UNKNOWN_EFFECT** |
 | **STOP_MOVED** |
 | **NO_EFFECT** |
+| **OUT_OF_SERVICE_ELEVATOR** |
 
 ## _enum_ SeverityLevel
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -309,7 +309,7 @@ The effect of this problem on the affected entity.
 | **UNKNOWN_EFFECT** |
 | **STOP_MOVED** |
 | **NO_EFFECT** |
-| **ACCESSBILITY_ISSUE** |
+| **ACCESSIBILITY_ISSUE** |
 
 ## _enum_ SeverityLevel
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -309,7 +309,7 @@ The effect of this problem on the affected entity.
 | **UNKNOWN_EFFECT** |
 | **STOP_MOVED** |
 | **NO_EFFECT** |
-| **OUT_OF_SERVICE_ELEVATOR** |
+| **ACCESSBILITY_ISSUE** |
 
 ## _enum_ SeverityLevel
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -59,3 +59,4 @@ What effect does this problem have on the specified entity? You may specify one 
 *   Other effect (not represented by any of these options)
 *   Unknown effect
 *   No effect: The alert provides information to riders but does not affect operations.  Examples include advertising public meetings and soliciting feedback via surveys.
+*   Out of service elevator

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -59,4 +59,4 @@ What effect does this problem have on the specified entity? You may specify one 
 *   Other effect (not represented by any of these options)
 *   Unknown effect
 *   No effect: The alert provides information to riders but does not affect operations.  Examples include advertising public meetings and soliciting feedback via surveys.
-*   Out of service elevator
+*   Accessibility issue: The alert provides information about accessibility issues that affects step-free access. Examples include an out of service elevator or movable ramps.


### PR DESCRIPTION
I've seen that a big amount of alert available in GTFS-rt alerts feed are to give the status of elevator that are out of service. However, there was no Effect available in the enum to mark them as such. 

This adds that value in the Effect enum. 