### PR TITLE
Fix #94 - Clarify that GTFS-rt extension field numbers are permanent

### DIFF
--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -85,6 +85,20 @@ extend transit_realtime.TripDescriptor {
 }
 ```
 
+When creating extensions, developers should follow the [Protocol Buffers Language Guide](https://developers.google.com/protocol-buffers/docs/proto). A common mistake is re-using an extension field number. In the [Assigning Field Numbers section](https://developers.google.com/protocol-buffers/docs/proto#assigning-field-numbers), the Language Guide says:
+
+> Each field in the message definition has a unique number. These numbers are used to identify your fields in the message binary format, and should not be changed once your message type is in use.
+
+For example, in the first example `some_string` was assigned field number `1`. When the developer no longer wishes to use `some_string`, or when `some_string` has been adopted in the official GTFS Realtime spec and there is no need for the extension, the developer cannot re-use field number `1` for a new field. Instead, the developer should deprecate the field and use a new number for the new field:
+```
+message MyTripDescriptorExtension {
+  optional string some_string = 1 [deprecated=true];
+  optional bool some_bool = 2;
+  optional string some_new_string = 3;
+  ...
+}
+```
+
 ### Extension Registry
 
 |Extension ID|Developer|Contact|Details|


### PR DESCRIPTION
As discussed in https://github.com/google/transit/issues/94, some producers have mistakenly re-used field numbers in GTFS-realtime extensions - for example, when an extension was officially adopted, the producer would recycle that field number in their extension for a new extension field.

This proposal adds guidance that currently exists in the [Protocol Buffers Language Guide](https://developers.google.com/protocol-buffers/docs/proto) directly in the GTFS-realtime extension documentation in regards to not re-using extension field numbers to make it more obvious to producers.

Announced on the GTFS-realtime Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/BIh8jXEm_Vc.