### PR TITLE
GTFS-Attributions (core only)

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -82,6 +82,7 @@ This specification defines the following files:
 |  [pathways.txt](#pathwaystxt)  | Optional | Pathways linking together locations within stations. |
 |  [levels.txt](#levelstxt)  | Optional | Levels within stations. |
 |  [feed_info.txt](#feed_infotxt)  | Optional | Dataset metadata, including publisher, version, and expiration information. |
+|  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
 
 ## File Requirements
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -359,6 +359,7 @@ Describe the different levels of a station. Is mostly useful when used in conjun
 |  `level_index` | Float | **Required** | Numeric index of the level that indicates relative position of this level in relation to other levels (levels with higher indices are assumed to be located above levels with lower indices).<br><br>Ground level should have index 0, with levels above ground indicated by positive indices and levels below ground by negative indices.|
 |  `level_name` | Text | Optional | Optional name of the level (that matches level lettering/numbering used inside the building or the station). Is useful for elevator routing (e.g. “take the elevator to level “Mezzanine” or “Platforms” or “-1”).|
 
+
 ### feed_info.txt
 
 File: **Optional**
@@ -389,7 +390,7 @@ The file defines the attributions applied to the dataset.
 |  `route_id` |  ID referencing `routes.route_id`  | Optional | Functions in the same way as `agency_id` except the attribution applies to a route. Multiple attributions can apply to the same route. |
 |  `trip_id` |  ID referencing `trips.trip_id`  | Optional | Functions in the same way as `agency_id` except the attribution applies to a trip. Multiple attributions can apply to the same trip. |
 |  `organization_name` | Text | **Required** | Name of the organization that the dataset is attributed to. |
-|  `is_producer` | Enum | Optional | The role of the organization is producer. Valid options are:<br><br>`0` or empty - Organization doesn’t have this role.<br>`1` - Organization does have this role.<br><br>At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set at `1`. If none of them is set to `1` (e.g. because they are non-official fields defining other types of attribution), the data consumer is allowed to ignore them. |
+|  `is_producer` | Enum | Optional | The role of the organization is producer. Valid options are:<br><br>`0` or empty - Organization doesn’t have this role.<br>`1` - Organization does have this role.<br><br>At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set at `1`. |
 |  `is_operator` | Enum | Optional | Functions in the same way as `is_producer` except the role of the organization is operator. |
 |  `is authority` | Enum | Optional | Functions in the same way as `is_producer` except the role of the organization is authority. |
 |  `attribution_url` | URL | Optional | URL of the organization. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -26,6 +26,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [pathways.txt](#pathwaystxt)
     -   [levels.txt](#levelstxt)
     -   [feed\_info.txt](#feed_infotxt)
+    -   [attributions.txt](#attributionstxt)
 
 ## Term Definitions
 
@@ -358,7 +359,6 @@ Describe the different levels of a station. Is mostly useful when used in conjun
 |  `level_index` | Float | **Required** | Numeric index of the level that indicates relative position of this level in relation to other levels (levels with higher indices are assumed to be located above levels with lower indices).<br><br>Ground level should have index 0, with levels above ground indicated by positive indices and levels below ground by negative indices.|
 |  `level_name` | Text | Optional | Optional name of the level (that matches level lettering/numbering used inside the building or the station). Is useful for elevator routing (e.g. “take the elevator to level “Mezzanine” or “Platforms” or “-1”).|
 
-
 ### feed_info.txt
 
 File: **Optional**
@@ -375,3 +375,23 @@ The file contains information about the dataset itself, rather than the services
 |  `feed_version` | Text | Optional | String that indicates the current version of their GTFS dataset. GTFS-consuming applications can display this value to help dataset publishers determine whether the latest dataset has been incorporated. |
 |  `feed_contact_email` | Email | Optional | Email address for communication regarding the GTFS dataset and data publishing practices. `feed_contact_email` is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](#agencytxt). |
 |  `feed_contact_url` | URL | Optional | URL for contact information, a web-form, support desk, or other tools for communication regarding the GTFS dataset and data publishing practices. `feed_contact_url` is a technical contact for GTFS-consuming applications. Provide customer service contact information through [agency.txt](#agencytxt). |
+
+### attributions.txt
+
+File: **Optional**
+
+The file defines the attributions applied to the dataset.
+
+|  Field Name | Type | Required | Description |
+|  ------ | ------ | ------ | ------ |
+|  `attribution_id` | ID | Optional | Identifies an attribution for the dataset or a subset of it. This is mostly useful for translations. |
+|  `agency_id` | ID referencing `agency.agency_id` | Optional | Agency to which the attribution applies.<br><br>If one `agency_id`, `route_id`, or `trip_id` attribution is defined, the other ones must be empty. If none of them is specified, the attribution will apply to the whole dataset. |
+|  `route_id` |  ID referencing `routes.route_id`  | Optional | Functions in the same way as `agency_id` except the attribution applies to a route. Multiple attributions can apply to the same route. |
+|  `trip_id` |  ID referencing `trips.trip_id`  | Optional | Functions in the same way as `agency_id` except the attribution applies to a trip. Multiple attributions can apply to the same trip. |
+|  `organization_name` | Text | **Required** | Name of the organization that the dataset is attributed to. |
+|  `is_producer` | Enum | Optional | The role of the organization is producer. Valid options are:<br><br>`0` or empty - Organization doesn’t have this role.<br>`1` - Organization does have this role.<br><br>At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set at `1`. If none of them is set to `1` (e.g. because they are non-official fields defining other types of attribution), the data consumer is allowed to ignore them. |
+|  `is_operator` | Enum | Optional | Functions in the same way as `is_producer` except the role of the organization is operator. |
+|  `is authority` | Enum | Optional | Functions in the same way as `is_producer` except the role of the organization is authority. |
+|  `attribution_url` | URL | Optional | URL of the organization. |
+|  `attribution_email` | Email | Optional | Email of the organization. |
+|  `attribution_phone` | Phone number | Optional | Phone number of the organization. |


### PR DESCRIPTION
### Context

Some data producers would like to provide more data attributions. The existing fields `feed_publisher_url` and `agency_name` aren't enough, because many other stakeholders may be implied and they should be given credit.

Given the broad variety of such stakeholders (French "Autorité Organisatrice", German "Verbund", the SF Bay Area MTC which is "planning, financing and coordinating", aggregators like Danish Rejseplannen...), the proposal allows to name them freely and to classify them as necessary either as producers, operators, or authorities.

The Danish data producer Rejseplanen is already producing the file attributions.txt according to this proposal. Datasets are available [here (new version)](http://www.rejseplanen.info/labs/GTFS_New.zip) or [here (old version)](http://www.rejseplanen.info/labs/GTFS_Old.zip) — both versions include attributions.txt.

Google is also consuming the attributions.txt file.

### Pull request

This PR is related to the issue [Attributions in GTFS](https://github.com/google/transit/issues/138) and concerns the proposal [GTFS-Attributions (core only)](http://bit.ly/gtfs-attributions-core) according to the current (2019-12-02T18:08:00-05:00) state of the Google Doc.

This PR suggests the addition of:
- attributions.txt (new file)

Compared to [GTFS-Attributions full version]( http://bit.ly/gtfs-attributions), this PR _does not_ include:
- attribution_scopes.txt (new file)
- translations.txt (extended file - still at the proposal step)
