### PR TITLE
Update proto to match bindings of service changesv3.1

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -131,6 +131,7 @@ message TripProperties {
   optional TranslatedString trip_short_name = 6;
   optional string block_id = 7;
   optional string shape_id = 8;
+
 }
 
 
@@ -200,6 +201,31 @@ message ShapePoint{
   required float shape_pt_lon = 2;
   optional float shape_dist_traveled = 3;
 }
+
+message Route{
+  required string route_id = 1;
+  required string agency_id = 2;
+  optional TranslatedString route_short_name = 3;
+  optional TranslatedString route_long_name = 4;
+  optional TranslatedString route_desc = 5;
+  optional RouteType route_type = 6;
+  optional TranslatedString route_url = 7;
+  optional string route_color = 8;
+  optional string route_text_color = 9;
+  optional uint32 route_sort_order = 10;
+
+  enum RouteType{
+    LIGHT_RAIL = 0;
+    SUBWAY = 1;
+    RAIL = 2;
+    BUS = 3;
+    FERRY = 4;
+    CABLE_CAR =5;
+    GONDOLA = 6;
+    FUNICULAR =7;
+  }
+}
+
 // A definition (or update) of an entity in the transit feed.
 message FeedEntity {
   // The ids are used only to provide incrementality support. The id should be
@@ -223,6 +249,7 @@ message FeedEntity {
   optional Alert alert = 5;
   optional Trip trip = 6;
   optional Shape shape = 7;
+  optional Route route = 8;
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -26,6 +26,32 @@ syntax = "proto2";
 option java_package = "com.google.transit.realtime";
 package transit_realtime;
 
+message StopTime{
+  required int64 stop_sequence = 1;
+  required Timestamp arrival_time = 2;
+  required Timestamp departure_time = 3;
+  required string stop_id = 4;
+  optional TranslatedString stop_headsign = 5;
+  optional PickupType pickup_type = 6;
+  optional DropOffType drop_off_type = 7;
+  optional float shape_dist_traveled = 8;
+
+  enum PickupType{
+    REGULAR_PICKUP = 0;
+    NO_PICKUP = 1;
+    MUST_PHONE_AGENCY = 2;
+    MUST_ASK_DRIVER = 3;
+  }
+
+  enum DropOffType{
+    REGULAR_DROP_OFF = 0;
+    NO_DROP_OFF = 1;
+    MUST_PHONE_AGENCY = 2;
+    MUST_ASK_DRIVER = 3;
+  }
+
+}
+
 message StopTimeProperties{
   optional string platform_id = 1;
   optional TranslatedString stop_headsign = 2;
@@ -164,6 +190,16 @@ message FeedHeader {
   extensions 9000 to 9999;
 }
 
+message Shape{
+  required string shape_id = 1;
+  required ShapePoint shape_point = 2;
+}
+
+message ShapePoint{
+  required float shape_pt_lat = 1;
+  required float shape_pt_lon = 2;
+  optional float shape_dist_traveled = 3;
+}
 // A definition (or update) of an entity in the transit feed.
 message FeedEntity {
   // The ids are used only to provide incrementality support. The id should be
@@ -186,7 +222,7 @@ message FeedEntity {
   optional VehiclePosition vehicle = 4;
   optional Alert alert = 5;
   optional Trip trip = 6;
-
+  optional Shape shape = 7;
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -26,6 +26,20 @@ syntax = "proto2";
 option java_package = "com.google.transit.realtime";
 package transit_realtime;
 
+
+message TripProperties {
+  // Metadata about this feed and feed message.
+  required string id = 1;
+  required string start_date = 2;
+  required string start_time = 3;
+  optional string route_id = 4;
+  optional TranslatedString trip_headsign = 5;
+  optional TranslatedString trip_short_name = 6;
+  optional string block_id = 7;
+  optional string shape_id = 8;
+}
+
+
 // The contents of a feed message.
 // A feed is a continuous stream of feed messages. Each message in the stream is
 // obtained as a response to an appropriate HTTP GET request.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -26,6 +26,74 @@ syntax = "proto2";
 option java_package = "com.google.transit.realtime";
 package transit_realtime;
 
+message StopTimeProperties{
+  optional string platform_id = 1;
+  optional TranslatedString stop_headsign = 2;
+  optional PickupType pickup_type = 3;
+  optional DropOffType drop_off_type = 4;
+  optional float shape_dist_traveled = 5;
+
+  enum PickupType{
+    REGULAR_PICKUP = 0;
+    NO_PICKUP = 1;
+    MUST_PHONE_AGENCY = 2;
+    MUST_ASK_DRIVER = 3;
+  }
+
+  enum DropOffType{
+    REGULAR_DROP_OFF = 0;
+    NO_DROP_OFF = 1;
+    MUST_PHONE_AGENCY = 2;
+    MUST_ASK_DRIVER = 3;
+  }
+}
+
+message VehicleProperties{
+  optional WheelchairAccessibleStatus wheelchair_accessible = 1;
+  optional BikesAllowedSatus biked_allowed = 2;
+
+  enum WheelchairAccessibleStatus{
+    UNKNOWN_WHEELCHAIR_ACCESSIBILITY = 0;
+    WHEELCHAIR_ACCESSIBLE = 1;
+    NOT_WHEELCHAIR_ACCESSIBLE = 2;
+  }
+
+  enum BikesAllowedSatus{
+    UNKNOWN_BIKES_ALLOWANCE = 0;
+    BIKES_ALLOWED = 1;
+    BIKES_NOT_ALLOWED = 2;
+  }
+}
+
+
+message Trip {
+
+  required string trip_id = 1;
+  optional string route_id = 2;
+  required TranslatedString trip_headsign = 3 ;
+  required string trip_short_name = 4;
+  optional int64 direction_id = 5;
+  optional string block_id = 6;
+  optional string shape_id = 7;
+  optional WheelchairAccessibleStatus wheelchair_accessible = 8;
+  optional BikesAllowedSatus biked_allowed = 9;
+  optional string replaces_trip_id = 10;
+
+  enum WheelchairAccessibleStatus{
+    UNKNOWN_WHEELCHAIR_ACCESSIBILITY = 0;
+    WHEELCHAIR_ACCESSIBLE = 1;
+    NOT_WHEELCHAIR_ACCESSIBLE = 2;
+  }
+
+  enum BikesAllowedSatus{
+    UNKNOWN_BIKES_ALLOWANCE = 0;
+    BIKES_ALLOWED = 1;
+    BIKES_NOT_ALLOWED = 2;
+  }
+
+
+
+}
 
 message TripProperties {
   // Metadata about this feed and feed message.
@@ -117,6 +185,7 @@ message FeedEntity {
   optional TripUpdate trip_update = 3;
   optional VehiclePosition vehicle = 4;
   optional Alert alert = 5;
+  optional Trip trip = 6;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
@@ -199,6 +268,8 @@ message TripUpdate {
     // To specify a completely certain prediction, set its uncertainty to 0.
     optional int32 uncertainty = 3;
 
+    optional int64 scheduled_time = 4;
+
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
@@ -256,6 +327,8 @@ message TripUpdate {
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
 
+    optional StopTimeProperties stop_time_properties = 6;
+
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
@@ -309,6 +382,10 @@ message TripUpdate {
   // NOTE: This field is still experimental, and subject to change. It may be
   // formally adopted in the future.
   optional int32 delay = 5;
+  optional TripProperties trip_properties = 6;
+  optional VehicleProperties vehicle_properties = 7;
+
+
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -28,8 +28,8 @@ package transit_realtime;
 
 message StopTime{
   required int64 stop_sequence = 1;
-  required Timestamp arrival_time = 2;
-  required Timestamp departure_time = 3;
+  required uint64 arrival_time = 2;
+  required uint64 departure_time = 3;
   required string stop_id = 4;
   optional TranslatedString stop_headsign = 5;
   optional PickupType pickup_type = 6;

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -58,6 +58,7 @@ message StopTimeProperties{
   optional PickupType pickup_type = 3;
   optional DropOffType drop_off_type = 4;
   optional float shape_dist_traveled = 5;
+  optional string stop_id = 6;
 
   enum PickupType{
     REGULAR_PICKUP = 0;
@@ -226,6 +227,30 @@ message Route{
   }
 }
 
+message Stop{
+  required string stop_id = 1;
+  optional string stop_code = 2;
+  required TranslatedString stop_name = 3;
+  optional TranslatedString stop_desc = 4;
+  required float stop_lat = 5;
+  required float stop_lon = 6;
+  optional string zone_id = 7;
+  optional TranslatedString stop_url = 8;
+  optional string parent_station = 9;
+  optional string stop_timezone = 10;
+  optional WheelchairBoardingStatus wheelchair_boarding = 11;
+  optional string level_id = 12;
+  optional string platform_code = 13;
+
+  enum WheelchairBoardingStatus{
+    UNKNOWN_WHEELCHAIR_BOARDING = 0;
+    WHEELCHAIR_ACCESSIBLE = 1;
+    NOT_WHEELCHAIR_ACCESSIBLE = 2;
+  }
+
+
+}
+
 // A definition (or update) of an entity in the transit feed.
 message FeedEntity {
   // The ids are used only to provide incrementality support. The id should be
@@ -250,6 +275,7 @@ message FeedEntity {
   optional Trip trip = 6;
   optional Shape shape = 7;
   optional Route route = 8;
+  optional Stop stop = 9;
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.


### PR DESCRIPTION
This PR consists in a first attempt to merge the modifications from ServiceChanges v3.1 into the current .proto file for realtime GTFS feed.

See : 
- https://github.com/google/transit/issues/113#issuecomment-577715581 
- proposal : https://docs.google.com/document/d/1oPfQ6Xvui0g3xiy1pNiyu5cWFLhvrTVyvYsMVKGyGWM/edit

