### PR TITLE
fix: Add translations.txt to the files table

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -82,7 +82,7 @@ This specification defines the following files:
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
 |  [pathways.txt](#pathwaystxt)  | Optional | Pathways linking together locations within stations. |
 |  [levels.txt](#levelstxt)  | Optional | Levels within stations. |
-|  [translations.txt](#translationstxt)  | Optional | Translations of dataset values. |
+|  [translations.txt](#translationstxt)  | Optional | Translations of customer-facing dataset values. |
 |  [feed_info.txt](#feed_infotxt)  | Optional | Dataset metadata, including publisher, version, and expiration information. |
 |  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -86,8 +86,6 @@ This specification defines the following files:
 |  [feed_info.txt](#feed_infotxt)  | Optional | Dataset metadata, including publisher, version, and expiration information. |
 |  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
 
-[translations.txt](#translationstxt)
-
 ## File Requirements
 
 The following requirements apply to the format and contents of the dataset files:

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -82,8 +82,11 @@ This specification defines the following files:
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
 |  [pathways.txt](#pathwaystxt)  | Optional | Pathways linking together locations within stations. |
 |  [levels.txt](#levelstxt)  | Optional | Levels within stations. |
+|  [translations.txt](#translationstxt)  | Optional | Translations of dataset values. |
 |  [feed_info.txt](#feed_infotxt)  | Optional | Dataset metadata, including publisher, version, and expiration information. |
 |  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
+
+[translations.txt](#translationstxt)
 
 ## File Requirements
 


### PR DESCRIPTION
Editorial change - Add translations.txt to the files table. We must have missed adding it in the original PR.