### PR TITLE
Proposal: Label GTFS-RT ADDED trips as not fully specified

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -613,6 +613,10 @@ message TripDescriptor {
     // An extra trip that was added in addition to a running schedule, for
     // example, to replace a broken vehicle or to respond to sudden passenger
     // load.
+    // NOTE: Currently, behavior is unspecified for feeds that use this mode. There are discussions on the GTFS GitHub
+    // [(1)](https://github.com/google/transit/issues/106) [(2)](https://github.com/google/transit/pull/221)
+    // [(3)](https://github.com/google/transit/pull/219) around fully specifying or deprecating ADDED trips and the
+    // documentation will be updated when those discussions are finalized.
     ADDED = 1;
 
     // A trip that is running with no schedule associated to it (GTFS frequencies.txt exact_times=0).

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -394,7 +394,7 @@ The relation between this trip and the static schedule. If a trip is done in acc
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
 | **SCHEDULED** | Trip that is running in accordance with its GTFS schedule, or is close enough to the scheduled trip to be associated with it. |
-| **ADDED** | An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to respond to sudden passenger load. |
+| **ADDED** | An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to respond to sudden passenger load. *NOTE: Currently, behavior is unspecified for feeds that use this mode. There are discussions on the GTFS GitHub [(1)](https://github.com/google/transit/issues/106) [(2)](https://github.com/google/transit/pull/221) [(3)](https://github.com/google/transit/pull/219) around fully specifying or deprecating ADDED trips and the documentation will be updated when those discussions are finalized.* |
 | **UNSCHEDULED** | A trip that is running with no schedule associated to it - this value is used to identify trips defined in GTFS frequencies.txt with exact_times = 0. It should not be used to describe trips not defined in GTFS frequencies.txt, or trips in GTFS frequencies.txt with exact_times = 1. Trips with `schedule_relationship: UNSCHEDULED` must also set all StopTimeUpdates `schedule_relationship: UNSCHEDULED`|
 | **CANCELED** | A trip that existed in the schedule but was removed. |
 


### PR DESCRIPTION
Given existing discussions around how to add or modify trips in GTFS-RT [(1)](https://github.com/google/transit/issues/106) [(2)](https://github.com/google/transit/pull/221) [(3)](https://github.com/google/transit/pull/219), I hope one thing we can all agree upon is that we don't currently agree upon how `ADDED` trips are produced or consumed.

This proposal puts a label on the `ADDED` enumeration to make this lack of agreement clear to newcomers to the spec while we discuss how these concepts should be represented, similar to how the [`DIFFERENTIAL` feature](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-incrementality) is currently labeled in the GTFS-RT spec.

cc @paulswartz @gcamp @skinkie @Bertware @tleboulenge @darylweinberg @juanborre @hbruch @nathan-reynolds @lauramatson

Posted to the Google Group at https://groups.google.com/forum/#!topic/gtfs-realtime/p8pXNzGOafQ.