### PR TITLE
Proposal: Support multi-car crowding in GTFS-RT

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -390,7 +390,7 @@ message VehiclePosition {
     // The vehicle is not accepting additional passengers.
     NOT_ACCEPTING_PASSENGERS = 6;
 
-    // Used in context of multi car crowding. There is no data available for this car in this vehicle
+    // There is no data available for this car in this vehicle. Used in context of multi car crowding. 
     // Useful for padding, in case a vehicle composed of several cars has data available only for some of those
     NO_DATA_AVAILABLE = 7;
 

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -500,11 +500,9 @@ message Alert {
   optional TranslatedString description_text = 11;
 
   // Text for alert header to be used in text-to-speech implementations. This field is the text-to-speech version of header_text.
-  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString tts_header_text = 12;
 
   // Text for full description for the alert to be used in text-to-speech implementations. This field is the text-to-speech version of description_text.
-  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString tts_description_text = 13;
 
   // Severity of this alert.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -390,6 +390,10 @@ message VehiclePosition {
     // The vehicle is not accepting additional passengers.
     NOT_ACCEPTING_PASSENGERS = 6;
 
+    // Used in context of multi car crowding. There is no data available for this car in this vehicle
+    // Useful for padding, in case a vehicle composed of several cars has data available only for some of those
+    NO_DATA_AVAILABLE = 7;
+
   }
   optional OccupancyStatus occupancy_status = 9;
 
@@ -401,6 +405,32 @@ message VehiclePosition {
   // The precision of occupancy_percentage should be low enough that you can't track a single person boarding and alighting for privacy reasons.
   // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional uint32 occupancy_percentage = 10;
+
+  // Car specific details, used for vehicles composed of several cars
+  message CarDetails {
+
+    // Occupancy status for this given car, in this vehicle
+    optional OccupancyStatus occupancy_status = 1;
+
+    // Occupancy percentage for this given car, in this vehicle
+    // Follows the same rules as "VehiclePosition.occupancy_percentage"
+    // In addition, value -1 will be used to determine that crowding percentage is currently not available for this given car
+    // -1 is useful for padding, in case a vehicle composed of several cars has data available only for some of those
+    optional int32 occupancy_percentage = 2;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+
+  // Details of the multiple cars of this given vehicle.
+  // The first occurence represents the first car of the vehicle, given the current direction of travel. 
+  // The number of occurrences of the multi_car_details field represents the number of cars of the vehicle.
+  repeated CarDetails multi_car_details = 11;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
@@ -470,9 +500,11 @@ message Alert {
   optional TranslatedString description_text = 11;
 
   // Text for alert header to be used in text-to-speech implementations. This field is the text-to-speech version of header_text.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString tts_header_text = 12;
 
   // Text for full description for the alert to be used in text-to-speech implementations. This field is the text-to-speech version of description_text.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString tts_description_text = 13;
 
   // Severity of this alert.


### PR DESCRIPTION
### **Background**

GTFS provides a way to surface vehicle crowding data as part of the VehiclePosition message using [`occupancyStatus`](https://developers.google.com/transit/gtfs-realtime/reference#enum-occupancystatus). An experimental field [`occupancy_percentage`](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto#L396) is also available.

These fields only provide crowding data at vehicle level. In case a vehicle is composed of several cars (like a subway or train), there is no way to provide details per car. This proposal offers a way to provide multi car crowding data in GTFS-RT.

### Proposal
To handle the case of vehicles that provide crowding data at car level, we would like to propose the addition of a new repeated `multi_car_details` field in the `VehiclePosition` message. This field would be based on a `CarDetails` message containing two fields: `occupancy_status` and `occupancy_percentage`.

`CarDetails.occupancy_status` would follow the values of [`OccupancyStatus`](https://developers.google.com/transit/gtfs-realtime/reference#enum-occupancystatus) enum. `CarDetails.occupancy_percentage` would follow [the same rules](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto#L396) than the ones defined for `occupancy_percentage` field (see Special Cases section below for details about unavailable data).

The first occurence of the repeated field would represent the first car of the vehicle, **given the current direction of travel**. The number of occurrences of the `multi_car_details` field represents the number of cars of the vehicle.

In a given occurrence of the repeated `multi_car_details` field, the `CarDetails.occupancy_status` and `CarDetails.occupancy_percentage` fields are not mutually exclusive.

### Special Cases
**Case when data is unavailable for some cars of the vehicle**
The structure also needs to accurately handle cases where the data is not available for all the cars of the vehicle. For `CarDetails.occupancy_status`, we propose to use a new `DATA_NOT_AVAILABLE` value in `OccupancyStatus` enum. For `Car.occupancy_percentage`, as we are using an `int32`, we could use `-1` to determine that data is not available for this specific car.

_Example for `CarDetails.occupancy_status`_: Vehicle is composed of three cars. Data is available only for first and third cars. To handle correctly the "padding", the repetition of `CarDetails.occupancy_status` would be the following: `STANDING_ROOM_ONLY`, `DATA_NOT_AVAILABLE`, `MANY_SEATS_AVAILABLE`.

_Example for `CarDetails.occupancy_percentage`:_ Vehicle is composed of three cars. Data is available only for first and third cars. To handle correctly the "padding", the repetition of `CarDetails.occupancy_percentage` would be the following: `15`, `-1`, `54`.

**Case when data is unavailable for the last cars of the vehicle**
The repeated `multi_car_details` field should contain a value for all the cars of the current vehicle.
_Example_: A vehicle is composed of 4 cars. The last two cars don't have crowding data available, due to faulty sensors.
The repetition of `CarDetails.occupancy_status` would be the following: `STANDING_ROOM_ONLY`, `MANY_SEATS_AVAILABLE`, `DATA_NOT_AVAILABLE`, `DATA_NOT_AVAILABLE`.