### PR TITLE
fix: Add extensions to TripProperties, remove extra comment

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -323,6 +323,14 @@ message TripUpdate {
     // populated and will be ignored by consumers.
     // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
     optional string start_time = 3;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features
+    // and modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
   optional TripProperties trip_properties = 6;
 
@@ -676,7 +684,6 @@ message TripDescriptor {
     // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
     DUPLICATED = 6;
   }
-  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional ScheduleRelationship schedule_relationship = 4;
 
   // The extensions namespace allows 3rd-party developers to extend the


### PR DESCRIPTION
This is an editorial follow-up to https://github.com/google/transit/pull/221 to fix two items:
* New messages should have the extensions fields to allow 3rd party and internal extensions - this commit adds these fields to `TripProperties`
* An erroneous comment was added that labeled schedule_relationship as `experimental` - this commit removes it