### PR TITLE
fix: Define defaults for VehiclePosition occupancy percentage and status

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -437,18 +437,19 @@ message VehiclePosition {
   }
   // If multi_carriage_status is populated with per-carriage OccupancyStatus,
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
-  optional OccupancyStatus occupancy_status = 9;
+  optional OccupancyStatus occupancy_status = 9 [default = NO_DATA_AVAILABLE];
 
   // A percentage value representing the degree of passenger occupancy of the vehicle.
   // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
   // The value 100 should represent the total maximum occupancy the vehicle was designed for,
   // including both seated and standing capacity, and current operating regulations allow.
   // It is possible that the value goes over 100 if there are currently more passengers than what the vehicle was designed for.
+  // -1 in case data is not available for this vehicle (as protobuf defaults to 0 otherwise).
   // The precision of occupancy_percentage should be low enough that you can't track a single person boarding and alighting for privacy reasons.
   // If multi_carriage_status is populated with per-carriage occupancy_percentage, 
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   // This field is still experimental, and subject to change. It may be formally adopted in the future.
-  optional uint32 occupancy_percentage = 10;
+  optional int32 occupancy_percentage = 10 [default = -1];
 
   // Carriage specific details, used for vehicles composed of several carriages
   // This message/field is still experimental, and subject to change. It may be formally adopted in the future.


### PR DESCRIPTION
As discussed in https://github.com/google/transit/issues/247, default values aren't currently defined for `VehiclePosition.occupancy_percentage` and `VehiclePosition.occupancy_status`.

This pull request adds defaults for `VehiclePosition.occupancy_percentage` and `VehiclePosition.occupancy_status` so erroneous defaults aren't read by GTFS-realtime consumers.

TODO:
- [x] Test backwards compatibility for occupancy_status - Done for Java in https://github.com/MobilityData/gtfs-realtime-bindings/commit/a4464a4413fb7a5e71ae4781c76b51291aaa2931 in branch https://github.com/MobilityData/gtfs-realtime-bindings/tree/occupancy-defaults-status. No changes in behavior when reading post default PBs with pre-default code.
- [x] Test backwards compatibility for occupancy_percentage -  what happens when a -1 value that was serialized by a new int32 producer is read by a legacy consumer still using the uint32 in the .proto. Done for Java in https://github.com/MobilityData/gtfs-realtime-bindings/commit/48bd41addbdbe627aa189461897fdee35fec9a63 in branch https://github.com/MobilityData/gtfs-realtime-bindings/commits/occupancy-defaults-status-percentage. No changes in behavior when reading post default PBs with pre-default code, including reading -1 values for occupancy_percentage.
- [ ] Test reading -1 occupancy_percentage value on legacy C++ consumers

Fixes #247