### PR TITLE
Add CrowdLevel to VehiclePosition

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -481,7 +481,7 @@ message VehiclePosition {
   // If multi_carriage_details is populated with per-carriage CrowdLevel,
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   enum CrowdLevel {
-    // The vehicle of carriage does not have any crowd level data available at that time.
+    // The vehicle or carriage does not have any crowd level data available at that time.
     NO_DATA_AVAILABLE = 0;
 
     // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
@@ -521,15 +521,11 @@ message VehiclePosition {
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
     optional OccupancyStatus occupancy_status = 3 [default = NO_DATA_AVAILABLE];
 
-    // The passenger crowd level for this given carriage, in this vehicle.
-    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional CrowdLevel crowd_level = 4 [default = NO_DATA_AVAILABLE];
-
     // Occupancy percentage for this given carriage, in this vehicle.
     // Follows the same rules as "VehiclePosition.occupancy_percentage"
     // -1 in case data is not available for this given carriage (as protobuf defaults to 0 otherwise)
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional int32 occupancy_percentage = 5 [default = -1];
+    optional int32 occupancy_percentage = 4 [default = -1];
 
     // Identifies the order of this carriage with respect to the other
     // carriages in the vehicle's list of CarriageDetails.
@@ -542,7 +538,11 @@ message VehiclePosition {
     // Carriages without data must be represented with a valid carriage_sequence number and the fields 
     // without data should be omitted (alternately, those fields could also be included and set to the "no data" values).
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional uint32 carriage_sequence = 6;
+    optional uint32 carriage_sequence = 5;
+
+    // The passenger crowd level for this given carriage, in this vehicle.
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional CrowdLevel crowd_level = 6 [default = NO_DATA_AVAILABLE];
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -486,25 +486,6 @@ message VehiclePosition {
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   // This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional uint32 occupancy_percentage = 10;
-  
-  // The passenger crowd level for the vehicle or carriage.
-  // This field is still experimental, and subject to change. It may be formally adopted in the future.
-  // If multi_carriage_details is populated with per-carriage CrowdLevel,
-  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
-  enum CrowdLevel {
-    // The vehicle or carriage does not have any crowd level data available at that time.
-    NO_DATA = 0;
-
-    // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
-    NOT_CROWDED = 1;
-
-    // The vehicle or carriage has some crowding by most measures, having some passengers onboard.
-    SOME_CROWDING = 2;
-
-    // The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space.
-    CROWDED = 3;
-  }
-  optional CrowdLevel crowd_level = 11;
 
   // Carriage specific details, used for vehicles composed of several carriages
   // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
@@ -564,6 +545,25 @@ message VehiclePosition {
   // information to passengers about where to stand on a platform.
   // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
   repeated CarriageDetails multi_carriage_details = 11;
+
+  // The passenger crowd level for the vehicle or carriage.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
+  // If multi_carriage_details is populated with per-carriage CrowdLevel,
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
+  enum CrowdLevel {
+    // The vehicle or carriage does not have any crowd level data available at that time.
+    NO_DATA = 0;
+
+    // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
+    NOT_CROWDED = 1;
+
+    // The vehicle or carriage has some crowding by most measures, having some passengers onboard.
+    SOME_CROWDING = 2;
+
+    // The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space.
+    CROWDED = 3;
+  }
+  optional CrowdLevel crowd_level = 12;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -464,7 +464,7 @@ message VehiclePosition {
     // The vehicle or carriage is not accepting passengers, but usually accepts passengers for boarding.
     NOT_ACCEPTING_PASSENGERS = 6;
 
-    // The vehicle or carriage doesn't have any occupancy data available at that time.
+    // The vehicle or carriage does not have any occupancy data available at this time.
     NO_DATA_AVAILABLE = 7;
 
     // The vehicle or carriage is not boardable and never accepts passengers.
@@ -551,7 +551,7 @@ message VehiclePosition {
   // If multi_carriage_details is populated with per-carriage CrowdLevel,
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   enum CrowdLevel {
-    // The vehicle or carriage does not have any crowd level data available at that time.
+    // The vehicle or carriage does not have any crowd level data available at this time.
     NO_DATA = 0;
 
     // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
@@ -563,7 +563,7 @@ message VehiclePosition {
     // The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space.
     CROWDED = 3;
   }
-  optional CrowdLevel crowd_level = 12;
+  optional CrowdLevel crowd_level = 12 [default = NO_DATA];
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -493,7 +493,7 @@ message VehiclePosition {
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   enum CrowdLevel {
     // The vehicle or carriage does not have any crowd level data available at that time.
-    NO_DATA_AVAILABLE = 0;
+    NO_DATA = 0;
 
     // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
     NOT_CROWDED = 1;
@@ -543,7 +543,7 @@ message VehiclePosition {
 
     // The passenger crowd level for this given carriage, in this vehicle.
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional CrowdLevel crowd_level = 6 [default = NO_DATA_AVAILABLE];
+    optional CrowdLevel crowd_level = 6 [default = NO_DATA];
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -476,6 +476,24 @@ message VehiclePosition {
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   optional OccupancyStatus occupancy_status = 9;
 
+  // The passenger crowd level for the vehicle or carriage.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
+  // If multi_carriage_details is populated with per-carriage CrowdLevel,
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
+  enum CrowdLevel {
+    // The vehicle of carriage does not have any crowd level data available at that time.
+    NO_DATA_AVAILABLE = 0;
+
+    // The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard.
+    NOT_CROWDED = 1;
+
+    // The vehicle or carriage has some crowding by most measures, having some passengers onboard.
+    SOME_CROWDING = 2;
+
+    // The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space.
+    CROWDED = 3;
+  }
+
   // A percentage value indicating the degree of passenger occupancy in the vehicle.
   // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
   // The value 100 should represent the total maximum occupancy the vehicle was designed for,
@@ -503,11 +521,15 @@ message VehiclePosition {
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
     optional OccupancyStatus occupancy_status = 3 [default = NO_DATA_AVAILABLE];
 
+    // The passenger crowd level for this given carriage, in this vehicle.
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional CrowdLevel crowd_level = 4 [default = NO_DATA_AVAILABLE];
+
     // Occupancy percentage for this given carriage, in this vehicle.
     // Follows the same rules as "VehiclePosition.occupancy_percentage"
     // -1 in case data is not available for this given carriage (as protobuf defaults to 0 otherwise)
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional int32 occupancy_percentage = 4 [default = -1];
+    optional int32 occupancy_percentage = 5 [default = -1];
 
     // Identifies the order of this carriage with respect to the other
     // carriages in the vehicle's list of CarriageDetails.
@@ -520,7 +542,7 @@ message VehiclePosition {
     // Carriages without data must be represented with a valid carriage_sequence number and the fields 
     // without data should be omitted (alternately, those fields could also be included and set to the "no data" values).
     // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
-    optional uint32 carriage_sequence = 5;
+    optional uint32 carriage_sequence = 6;
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -476,6 +476,17 @@ message VehiclePosition {
   // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   optional OccupancyStatus occupancy_status = 9;
 
+  // A percentage value indicating the degree of passenger occupancy in the vehicle.
+  // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
+  // The value 100 should represent the total maximum occupancy the vehicle was designed for,
+  // including both seated and standing capacity, and current operating regulations allow.
+  // The value may exceed 100 if there are more passengers than the maximum designed capacity.
+  // The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle.
+  // If multi_carriage_status is populated with per-carriage occupancy_percentage, 
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional uint32 occupancy_percentage = 10;
+  
   // The passenger crowd level for the vehicle or carriage.
   // This field is still experimental, and subject to change. It may be formally adopted in the future.
   // If multi_carriage_details is populated with per-carriage CrowdLevel,
@@ -493,17 +504,7 @@ message VehiclePosition {
     // The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space.
     CROWDED = 3;
   }
-
-  // A percentage value indicating the degree of passenger occupancy in the vehicle.
-  // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
-  // The value 100 should represent the total maximum occupancy the vehicle was designed for,
-  // including both seated and standing capacity, and current operating regulations allow.
-  // The value may exceed 100 if there are more passengers than the maximum designed capacity.
-  // The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle.
-  // If multi_carriage_status is populated with per-carriage occupancy_percentage, 
-  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
-  // This field is still experimental, and subject to change. It may be formally adopted in the future.
-  optional uint32 occupancy_percentage = 10;
+  optional CrowdLevel crowd_level = 11;
 
   // Carriage specific details, used for vehicles composed of several carriages
   // This message/field is still experimental, and subject to change. It may be formally adopted in the future.

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -283,7 +283,7 @@ Individual producers may not publish all OccupancyStatus values. Therefore, cons
 
 To describe passenger crowd levels on an ordinal scale, see [CrowdLevel](#enum-crowdlevel).
 
-Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have _**FEW_SEATS_AVAILABLE**_ and _**SOME_CROWDING**_, have _**STANDING_ROOM_ONLY**_ and be _**CROWDED**_, or is _**NOT_ACCEPTING_PASSENGERS**_ and is _**CROWDED**_.
+Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have **FEW_SEATS_AVAILABLE** and **SOME_CROWDING**, have **STANDING_ROOM_ONLY** and be **CROWDED**, or is **NOT_ACCEPTING_PASSENGERS** and is **CROWDED**.
 
 To describe passenger occupancy levels on a linear scale, see `occupancy_percentage`. 
 
@@ -293,32 +293,32 @@ To describe passenger occupancy levels on a linear scale, see `occupancy_percent
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| _**EMPTY**_ | _The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers._ |
-| _**MANY_SEATS_AVAILABLE**_ | _The vehicle or carriage has a large number of seats available. The amount of free seats out of the total seats available to be considered large enough to fall into this category is determined at the discretion of the producer._ |
-| _**FEW_SEATS_AVAILABLE**_ | _The vehicle or carriage has a small number of seats available. The amount of free seats out of the total seats available to be considered small enough to fall into this category is determined at the discretion of the producer._ |
-| _**STANDING_ROOM_ONLY**_ | _The vehicle or carriage can currently accommodate only standing passengers._ |
-| _**CRUSHED_STANDING_ROOM_ONLY**_ | _The vehicle or carriage can currently accommodate only standing passengers and has limited space for them._ |
-| _**FULL**_ | _The vehicle is considered full by most measures, but may still be allowing passengers to board._ |
-| _**NOT_ACCEPTING_PASSENGERS**_ | _The vehicle or carriage is not accepting passengers. The vehicle or carriage usually accepts passengers for boarding._ |
-| _**NO_DATA_AVAILABLE**_ | _The vehicle or carriage doesn't have any occupancy data available at that time._ |
-| _**NOT_BOARDABLE**_ | _The vehicle or carriage is not boardable and never accepts passengers. Useful for special vehicles or carriages (engine, maintenance carriage, etc…)._ |
+| **EMPTY** | The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers. |
+| **MANY_SEATS_AVAILABLE** | The vehicle or carriage has a large number of seats available. The amount of free seats out of the total seats available to be considered large enough to fall into this category is determined at the discretion of the producer. |
+| **FEW_SEATS_AVAILABLE** | The vehicle or carriage has a small number of seats available. The amount of free seats out of the total seats available to be considered small enough to fall into this category is determined at the discretion of the producer. |
+| **STANDING_ROOM_ONLY** | The vehicle or carriage can currently accommodate only standing passengers. |
+| **CRUSHED_STANDING_ROOM_ONLY** | The vehicle or carriage can currently accommodate only standing passengers and has limited space for them. |
+| **FULL**_ | The vehicle is considered full by most measures, but may still be allowing passengers to board. |
+| **NOT_ACCEPTING_PASSENGERS** | The vehicle or carriage is not accepting passengers. The vehicle or carriage usually accepts passengers for boarding. |
+| **NO_DATA_AVAILABLE** | The vehicle or carriage does not have any occupancy data available at this time. |
+| **NOT_BOARDABLE** | The vehicle or carriage is not boardable and never accepts passengers. Useful for special vehicles or carriages (engine, maintenance carriage, etc…). |
 
 ## _enum_ CrowdLevel
 
-The passenger crowd level for the vehicle or carriage. CrowdLevel enum values must be interpreted on an ordinal scale in increasing order from _**NOT_CROWDED**_ to _**CROWDED**_. In other words, producers must represent the lowest crowdedness level with _**NOT_CROWDED**_, the medium crowdedness level with _**SOME_CROWDING**_, and the highest crowdedness level with _**CROWDED**_. 
+The passenger crowd level for the vehicle or carriage. CrowdLevel enum values must be interpreted on an ordinal scale in increasing order from **NOT_CROWDED** to **CROWDED**. In other words, producers must represent the lowest crowdedness level with **NOT_CROWDED**, the medium crowdedness level with **SOME_CROWDING**, and the highest crowdedness level with **CROWDED**. 
 
 To describe in-vehicle occupancy states, see [OccupancyStatus](#enum-occupancystatus). 
 
-Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have _**FEW_SEATS_AVAILABLE**_ and _**SOME_CROWDING**_, have _**STANDING_ROOM_ONLY**_ and be _**CROWDED**_, or is _**NOT_ACCEPTING_PASSENGERS**_ and is _**CROWDED**_.
+Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have **FEW_SEATS_AVAILABLE** and **SOME_CROWDING**, have **STANDING_ROOM_ONLY** and be **CROWDED**, or is **NOT_ACCEPTING_PASSENGERS** and is **CROWDED**.
 
 **Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard, or as otherwise defined by current operating regulations._ |
-| _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard, or as otherwise defined by current operating regulations._ |
-| _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space, or as otherwise defined be current operating regulations._ |
-| _**NO_DATA**_ | _The vehicle or carriage does not have any crowd level data available at that time._ |
+| **NOT_CROWDED** | The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard, or as otherwise defined by current operating regulations. |
+| **SOME_CROWDING** | The vehicle or carriage has some crowding by most measures, having some passengers onboard, or as otherwise defined by current operating regulations. |
+| **CROWDED** | The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space, or as otherwise defined be current operating regulations. |
+| **NO_DATA** | The vehicle or carriage does not have any crowd level data available at this time. |
 
 ## _message_ CarriageDetails
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -314,7 +314,7 @@ To describe the in-vehicle occupancy state, see [OccupancyStatus](#enum-occupanc
 | _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard._ |
 | _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard._ |
 | _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space._ |
-| _**NO_DATA_AVAILABLE**_ | The vehicle of carriage does not have any crowd level data available at that time. |
+| _**NO_DATA_AVAILABLE**_ | _The vehicle of carriage does not have any crowd level data available at that time._ |
 
 ## _message_ CarriageDetails
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -59,6 +59,7 @@ Fields labeled as **experimental** are subject to change and not yet formally ad
             *   [VehicleStopStatus](#enum-vehiclestopstatus)
             *   [CongestionLevel](#enum-congestionlevel)
             *   [OccupancyStatus](#enum-occupancystatus)
+            *   [CrowdLevel](#enum-crowdlevel)
             *   [CarriageDetails](#message-carriagedetails)
         *   [Alert](#message-alert)
             *   [TimeRange](#message-timerange)
@@ -244,7 +245,8 @@ Realtime positioning information for a given vehicle.
 | **current_status** | [VehicleStopStatus](#enum-vehiclestopstatus) | Optional | One | The exact status of the vehicle with respect to the current stop. Ignored if current_stop_sequence is missing. |
 | **timestamp** | [uint64](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Moment at which the vehicle's position was measured. In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). |
 | **congestion_level** | [CongestionLevel](#enum-congestionlevel) | Optional | One |
-| **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | _Optional_ | One | The state of passenger occupancy for the vehicle or carriage. If multi_carriage_details is populated with per-carriage OccupancyStatus, then this field should describe the entire vehicle with all carriages accepting passengers considered.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
+| **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | The state of passenger occupancy for the vehicle or carriage. If multi_carriage_details is populated with per-carriage OccupancyStatus, then this field should describe the entire vehicle with all carriages accepting passengers considered.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
+| **crowd_level** | [CrowdLevel](#enum-crowdlevel) | Optional | One | The passenger crowd level for the vehicle or carriage. If multi_carriage_details is populated with per-carriage CrowdLevel, then this field should describe the entire vehicle with all carriages accepting passengers considered.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
 | **occupancy_percentage** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | A percentage value indicating the degree of passenger occupancy in the vehicle. The value 100 should represent the total maximum occupancy the vehicle was designed for, including both seating and standing capacity, and current operating regulations allow. The value may exceed 100 if there are more passengers than the maximum designed capacity. The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle. If multi_carriage_details is populated with per-carriage occupancy_percentage, then this field should describe the entire vehicle with all carriages accepting passengers considered.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **multi_carriage_details** | [CarriageDetails](#message-CarriageDetails) | Optional | Many | Details of the multiple carriages of this given vehicle. The first occurrence represents the first carriage of the vehicle, **given the current direction of travel**. The number of occurrences of the multi_carriage_details field represents the number of carriages of the vehicle. It also includes non boardable carriages, like engines, maintenance carriages, etc… as they provide valuable information to passengers about where to stand on a platform.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 
@@ -273,13 +275,15 @@ Congestion level that is affecting this vehicle.
 | **CONGESTION** |
 | **SEVERE_CONGESTION** |
 
-## _enum OccupancyStatus_
+## _enum_ OccupancyStatus
 
 The state of passenger occupancy for the vehicle or carriage.
 
 Individual producers may not publish all OccupancyStatus values. Therefore, consumers must not assume that the OccupancyStatus values follow a linear scale. Consumers should represent OccupancyStatus values as the state indicated and intended by the producer. Likewise, producers must use OccupancyStatus values that correspond to actual vehicle occupancy states.
 
-For describing passenger occupancy levels on a linear scale, see `occupancy_percentage`.
+To describe passenger crowd levels on an ordinal scale, see [CrowdLevel](#enum-crowdlevel).
+
+To describe passenger occupancy levels on a linear scale, see `occupancy_percentage`. 
 
 **Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
 
@@ -297,6 +301,20 @@ For describing passenger occupancy levels on a linear scale, see `occupancy_perc
 | _**NO_DATA_AVAILABLE**_ | _The vehicle or carriage doesn't have any occupancy data available at that time._ |
 | _**NOT_BOARDABLE**_ | _The vehicle or carriage is not boardable and never accepts passengers. Useful for special vehicles or carriages (engine, maintenance carriage, etc…)._ |
 
+## _enum_ CrowdLevel
+
+The passenger crowd level for the vehicle or carriage. CrowdLevel enum values must be interpreted on an ordinal scale in increasing order from _**NOT_CROWDED**_ to _**CROWDED**_. 
+
+To describe the in-vehicle occupancy state, see [OccupancyStatus](#enum-occupancystatus).
+
+**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
+
+| _**Value**_ | _**Comment**_ |
+|-------------|---------------|
+| _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard._ |
+| _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard._ |
+| _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space._ |
+| _**NO_DATA_AVAILABLE**_ | The vehicle of carriage does not have any crowd level data available at that time. |
 
 ## _message_ CarriageDetails
 
@@ -311,6 +329,7 @@ Carriage specific details, used for vehicles composed of several carriages.
 | **id** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Identification of the carriage. Should be unique per vehicle. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **label** | [string](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | User visible label that may be shown to the passenger to help identify the carriage. Example: "7712", "Car ABC-32", etc... <br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **occupancy_status** | [OccupancyStatus](#enum-occupancystatus) | Optional | One | Occupancy status for this given carriage, in this vehicle. Default is set to `NO_DATA_AVAILABLE`.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.|
+| **crowd_level** | [CrowdLevel](#enum-crowdlevel) | Optional | One | The passenger crowd level for this given carriage, in this vehicle.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **occupancy_percentage** | [int32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Optional | One | Occupancy percentage for this given carriage, in this vehicle. Follows the same rules as "VehiclePosition.occupancy_percentage". Use -1 in case data is not available for this given carriage.<br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **carriage_sequence** | [uint32](https://developers.google.com/protocol-buffers/docs/proto#scalar) | Required | One | Identifies the order of this carriage with respect to the other carriages in the vehicle's list of CarriageStatus. The first carriage in the direction of travel must have a value of 1. The second value corresponds to the second carriage in the direction of travel and must have a value of 2, and so forth. For example, the first carriage in the direction of travel has a value of 1. If the second carriage in the direction of travel has a value of 3, consumers will discard data for all carriages (i.e., the multi_carriage_details field). Carriages without data must be represented with a valid carriage_sequence number and the fields without data should be omitted (alternately, those fields could also be included and set to the "no data" values). <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -318,7 +318,7 @@ Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectiv
 | _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard, or as otherwise defined by current operating regulations._ |
 | _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard, or as otherwise defined by current operating regulations._ |
 | _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space, or as otherwise defined be current operating regulations._ |
-| _**NO_DATA_AVAILABLE**_ | _The vehicle or carriage does not have any crowd level data available at that time._ |
+| _**NO_DATA**_ | _The vehicle or carriage does not have any crowd level data available at that time._ |
 
 ## _message_ CarriageDetails
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -283,6 +283,8 @@ Individual producers may not publish all OccupancyStatus values. Therefore, cons
 
 To describe passenger crowd levels on an ordinal scale, see [CrowdLevel](#enum-crowdlevel).
 
+Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have _**FEW_SEATS_AVAILABLE**_ and _**SOME_CROWDING**_, have _**STANDING_ROOM_ONLY**_ and be _**CROWDED**_, or is _**NOT_ACCEPTING_PASSENGERS**_ and is _**CROWDED**_.
+
 To describe passenger occupancy levels on a linear scale, see `occupancy_percentage`. 
 
 **Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
@@ -303,18 +305,20 @@ To describe passenger occupancy levels on a linear scale, see `occupancy_percent
 
 ## _enum_ CrowdLevel
 
-The passenger crowd level for the vehicle or carriage. CrowdLevel enum values must be interpreted on an ordinal scale in increasing order from _**NOT_CROWDED**_ to _**CROWDED**_. 
+The passenger crowd level for the vehicle or carriage. CrowdLevel enum values must be interpreted on an ordinal scale in increasing order from _**NOT_CROWDED**_ to _**CROWDED**_. In other words, producers must represent the lowest crowdedness level with _**NOT_CROWDED**_, the medium crowdedness level with _**SOME_CROWDING**_, and the highest crowdedness level with _**CROWDED**_. 
 
-To describe the in-vehicle occupancy state, see [OccupancyStatus](#enum-occupancystatus).
+To describe in-vehicle occupancy states, see [OccupancyStatus](#enum-occupancystatus). 
+
+Both OccupancyStatus and CrowdLevel may be used side-by-side, but must respectively indicate true conditions. For example, a vehicle may have _**FEW_SEATS_AVAILABLE**_ and _**SOME_CROWDING**_, have _**STANDING_ROOM_ONLY**_ and be _**CROWDED**_, or is _**NOT_ACCEPTING_PASSENGERS**_ and is _**CROWDED**_.
 
 **Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard._ |
-| _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard._ |
-| _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space._ |
-| _**NO_DATA_AVAILABLE**_ | _The vehicle of carriage does not have any crowd level data available at that time._ |
+| _**NOT_CROWDED**_ | _The vehicle or carriage is not considered crowded by most measures, having few or no passengers onboard, or as otherwise defined by current operating regulations._ |
+| _**SOME_CROWDING**_ | _The vehicle or carriage has some crowding by most measures, having some passengers onboard, or as otherwise defined by current operating regulations._ |
+| _**CROWDED**_ | _The vehicle or carriage is considered crowded by most measures, having many passengers onboard and limited space, or as otherwise defined be current operating regulations._ |
+| _**NO_DATA_AVAILABLE**_ | _The vehicle or carriage does not have any crowd level data available at that time._ |
 
 ## _message_ CarriageDetails
 


### PR DESCRIPTION
Hi everyone,

This pull request contains a proposal for CrowdLevel continuing from #212 and is based off of stakeholder interest in #223 for a description of occupancy levels in GTFS Realtime that are expressed as enum values on a simple ordinal scale (i.e., `NOT_CROWDED`, `SOME_CROWDING`, `CROWDED`).

This is in contrast to OccupancyStatus which has been clarified in #259 to describe occupancies by states (i.e., `MANY_SEATS_AVAILABLE`, `STANDING_ROOM_ONLY`, etc.) that cannot necessarily be attributed to a unversal linear scale (as seen in a few practices), as well as `occupancy_percentage` which describes occupancy ratio at a fine-grained level.

Note that this pull request is for the experimental adoption of CrowdLevel. Feedback is welcomed!