### PR TITLE
Update revision history

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -50,14 +50,22 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 ### Revision History
 
-#### May 28, 2020
+#### January 4, 2021
 
-* Updated major GTFS changes under "Revision History" in `CHANGES.md`. Last revised in January 2019 with some historical entries missing.
+* Clarified description of `stop_times.stop_id`. See [discussion](https://github.com/google/transit/pull/258).
+* Defined positive and non-zero field signs. See [discussion](https://github.com/google/transit/pull/251).
+
+#### October 2, 2020
+
+* Changed field type of `frequencies.headway_secs` from non-negative to positive integer. See [discussion](https://github.com/google/transit/pull/249).
+
+#### May 25, 2020
+
+* Defined `pathways.txt`, `levels.txt` and `attributions.txt` as translatable tables. Added recommendations for translating multilingual `signposted_as` values. See [discussion](https://github.com/google/transit/pull/220).
 
 #### May 13, 2020
 
-* Added `continuous_pickup` and `continuous_drop_off` to `routes.txt` and `stop_times.txt`.  See [discussion](https://github.com/google/transit/pull/208).
-* Changed `shape_id` from "Optional" to "Conditionally required". See [discussion](https://github.com/google/transit/pull/208).
+* Added `continuous_pickup` and `continuous_drop_off` to `routes.txt` and `stop_times.txt`. Changed `shape_id` from "Optional" to "Conditionally required". See [discussion](https://github.com/google/transit/pull/208).
 
 #### March 24, 2020
 
@@ -99,7 +107,7 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 #### March 27, 2019
 
-* Added `pathways.txt` and `levels.txt` to GTFS-static. See [discussion](https://github.com/google/transit/pull/143).
+* Added `pathways.txt` and `levels.txt`. See [discussion](https://github.com/google/transit/pull/143).
 
 #### February 6, 2019
 
@@ -107,11 +115,14 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 #### October 2, 2018
 
-* Factorized field types for conciseness.  See [discussion](https://github.com/google/transit/pull/104).
+* Factorized field types. See [discussion](https://github.com/google/transit/pull/104).
+
+#### September 14, 2018
+
+* Added "Conditionally required" concept. See [discussion](https://github.com/google/transit/pull/100).
 
 #### September 4, 2018
 
-* Added "Conditionally required" concept. See [discussion](https://github.com/google/transit/pull/100).
 * Unified the definitions of `agency_lang` and `feed_lang`. See [discussion](https://github.com/google/transit/pull/98).
 
 #### August 27, 2018

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised January 17, 2019. See [Revision History](../../CHANGES.md) for more details.**
+**Revised January 4, 2021. See [Revision History](../../CHANGES.md) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 


### PR DESCRIPTION
Update revision history as of last change on January 4, 2021.