### PR TITLE
Amend articles 7.4-8 of the Specification Amendment Process

### DIFF
--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -39,9 +39,9 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
   	- Votes against shall be motivated, and ideally provide actionable feedback.
   	- If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.
-  	- If the advocate continues the work on proposal then a new vote can be called for at any point in time but no later than 30 calendar days after the end of the previous vote.
-  	- If a vote was not called within 30 calendar days from the original proposal or 30 calendar days since end of the previous vote, then the proposal is abandoned.
-1. If the proposal is abandoned, the corresponding pull request is closed.  Note that the advocate may choose to implement the feature as an [custom extension](#extensions) instead of part of the official spec.
+  	- If the advocate continues the work on proposal then a new vote can be called for at any point in time.
+1. Any pull request remaining inactive for 30 calendar days will be closed. When a pull request is closed, the corresponding proposal is considered abandoned. The advocate may reopen the pull request at any time if they wish to continue or maintain the conversation. 
+ 	- Note that the advocate may choose to implement the feature as an [custom extension](#extensions) instead of part of the official spec.
 1. If the proposal is accepted:
   	- Google is committed to merging the voted upon version of the pull request (provided that the contributors have signed the [CLA](../CONTRIBUTING.md)), and performing the pull request within 5 business days.
   	- Google is committed to timely updating https://github.com/google/gtfs-realtime-bindings repository. Commits to gtfs-realtime-bindigs that are a result of a proposal, should reference the pull request of the proposal.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -24,9 +24,8 @@ The official specification, reference and documentation are written in English. 
   	- Votes against shall be motivated, and ideally provide actionable feedback.
   	- If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
     Either decision of the advocate must be announced in the mailing list.
-  	- If the advocate continues the work on proposal then a new vote can be called for at any point in time but no later than 30 calendar days after the end of the previous vote.
-  	- If a vote was not called within 30 calendar days from the original proposal or 30 calendar days since end of the previous vote, then the proposal is abandoned.
-1. If the proposal is abandoned, the corresponding pull request is closed.
+  	- If the advocate continues the work on proposal then a new vote can be called for at any point in time.
+1. Any pull request remaining inactive for 30 calendar days will be closed. When a pull request is closed, the corresponding proposal is considered abandoned. The advocate may reopen the pull request at any time if they wish to continue or maintain the conversation.
 1. If the proposal is accepted:
   	- Google is committed to merging the voted upon version of the pull request (provided that the contributors have signed the [CLA](../CONTRIBUTING.md)), and performing the pull request within 5 business days.
   	- Translations must not be included into the original pull request.


### PR DESCRIPTION
Hi GTFS community,

As consulted in #262, articles 7.4-8 of the [Specification Amendment Process](https://github.com/google/transit/blob/master/gtfs/CHANGES.md) for both GTFS Schedule and GTFS Realtime are not always followed. They state that:

> **7.4:** If the advocate continues the work on proposal then a new vote can be called for at any point in time but no later than 30 calendar days after the end of the previous vote.<br>
**7.5:** If a vote was not called within 30 calendar days from the original proposal or 30 calendar days since end of the previous vote, then the proposal is abandoned.<br>
 **8:** If the proposal is abandoned, the corresponding pull request is closed.
 
In practice, PRs almost always remain open well after the 30-day allowance or have otherwise been left inactive. This has led to noise in the repository and scatters focus on decision-making and participation. At the same time, it is often useful for the development and discussion of a given proposal to last longer than the prescribed 30-days. 

This proposal aims to: 
1. Bring the rules in alignment with the current practice. 
2. Have a changes process that is followed and respected throughout (and not only the pieces that are convenient).
3. Bring focus to relevant discussions.
4. Encode rules for clearing out stale PRs.
5. Establish a pace of decision-making in the community.

The proposal accomplishes this by allowing PRs to remain open for as long as relevant with the expectation that the PR will be closed after 30 days of inactivity (i.e., no new commits, no new comments). The advocate may renew the conversation at any time after it has been closed. 

We can discuss adjusting the amount of time to be shorter or longer (i.e., 60, 90 days).

Please see the "Files changed" tab for the changes. I have proposed the changes as separate commits for GTFS Schedule and GTFS Realtime to ease the review, though the changes to either file are equivalent. As this is a change that requires alignment in the community, we will use the current Specification Amendment Process to guide the proposal.

Please review and leave any actionable feedback! Thanks.