### PR TITLE
GTFS-Fares v2 base implementation

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -179,6 +179,7 @@ File: **Required**
 |  `route_sort_order` | Non-negative integer | Optional | Orders the routes in a way which is ideal for presentation to customers. Routes with smaller `route_sort_order` values should be displayed first. |
 |  `continuous_pickup` | Enum | Optional | Indicates that the rider can board the transit vehicle at any point along the vehicle’s travel path as described by `shapes.txt`, on every trip of the route. Valid options are: <br><br>`0` - Continuous stopping pickup. <br>`1` or empty - No continuous stopping pickup. <br>`2` - Must phone agency to arrange continuous stopping pickup. <br>`3` - Must coordinate with driver to arrange continuous stopping pickup.  <br><br>Values for `routes.continuous_pickup` may be overridden by defining values in `stop_times.continuous_pickup` for specific `stop_time`s along the route. |
 |  `continuous_drop_off` | Enum | Optional | Indicates that the rider can alight from the transit vehicle at any point along the vehicle’s travel path as described by `shapes.txt`, on every trip of the route. Valid options are: <br><br>`0` - Continuous stopping drop off. <br>`1` or empty - No continuous stopping drop off. <br>`2` - Must phone agency to arrange continuous stopping drop off. <br>`3` - Must coordinate with driver to arrange continuous stopping drop off. <br><br>Values for `routes.continuous_drop_off` may be overridden by defining values in `stop_times.continuous_drop_off` for specific `stop_time`s along the route. |
+| `network_id` | ID | Optional | Identifies a group of routes. Multiple rows in `routes.txt` may have the same `network_id`.| 
 
 ### trips.txt
 
@@ -305,10 +306,17 @@ File: **Conditionally Forbidden**
 
 Fare rules for individual legs of travel. 
 
-File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt.
+File `fare_leg_rules.txt` provides a more detailed method for modeling fare structures. As such, the use of `fare_leg_rules.txt` is entirely seperate from files `fare_attributes.txt` and `fare_rules.txt`.
+
+Fares in `fare_leg_rules.txt` are queried by filtering fields until a fare cost matches the characteristics of the leg. Undefined values in the fields that are filtered will be matched by default to empty values for that field. For example, a rider taking a route with `network_id=network1` that is not defined as a network in `fare_leg_rules.network_id` will be matched to entries with empty `fare_leg_rules.network_id`. 
+
+It is recommended that consumers filter `fare_leg_rules.txt` by the fields that define the characteristics of travel as outputted from trip planning software. This would give the immediate capability to display the cost of a leg from within a trip planner. The fields in `fare_leg_rules.txt` that define characteristics of travel are:
+- `fare_leg_rules.network_id`
+
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
+| `network_id` | ID referencing `routes.network_id` | Optional | Identifies a route network that applies for the fare leg rule.<br><br>If there are no matching `fare_leg_rules.network_id` values to the `network_id` being filtered, empty `fare_leg_rules.network_id` will be matched by default. |
 | `amount` | Non-negative currency amount | Optional | The cost of the fare for the leg. |
 | `currency` | Currency code | **Conditionally Required** | The currency of the fare for the leg.<br><br>Conditionally Required:<br>- **Required** if `fare_leg_rules.amount` is defined.<br>- **Forbidden** otherwise. |
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -19,8 +19,8 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [calendar\_dates.txt](#calendar_datestxt)
     -   [fare\_attributes.txt](#fare_attributestxt)
     -   [fare\_rules.txt](#fare_rulestxt)
-    -   [fare\_leg\_rules.txt](#farelegrulestxt)
-    -   [fare\_transfer\_rules.txt](#faretransferrulestxt)
+    -   [fare\_leg\_rules.txt](#fare_leg_rulestxt)
+    -   [fare\_transfer\_rules.txt](#fare_transfer_rulestxt)
     -   [areas.txt](areastxt)
     -   [shapes.txt](#shapestxt)
     -   [frequencies.txt](#frequenciestxt)
@@ -94,10 +94,10 @@ This specification defines the following files:
 |  [stop_times.txt](#stop_timestxt)  | **Required** | Times that a vehicle arrives at and departs from stops for each trip. |
 |  [calendar.txt](#calendartxt)  | **Conditionally Required** | Service dates specified using a weekly schedule with start and end dates. <br><br>Conditionally Required:<br> - **Required** unless all dates of service are defined in [calendar_dates.txt](#calendar_datestxt).<br> - Optional otherwise. |
 |  [calendar_dates.txt](#calendar_datestxt)  | **Conditionally Required** | Exceptions for the services defined in the [calendar.txt](#calendartxt). <br><br>Conditionally Required:<br> - **Required** if [calendar.txt](#calendartxt) is omitted. In which case [calendar_dates.txt](#calendar_datestxt) must contain all dates of service. <br> - Optional otherwise. |
-|  [fare_attributes.txt](#fare_attributestxt)  | **Conditionally Forbidden** | Fare information for a transit agency's routes.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
-|  [fare_rules.txt](#fare_rulestxt)  | **Conditionally Forbidden** | Rules to apply fares for itineraries.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
-|  [fare_leg_rules.txt](#farelegrulestxt)  | **Conditionally Forbidden** | Fare rules for individual legs of travel.<br><br>File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](farerulestxt) or [fare_attributes.txt](fareattributestxt) are defined.<br>- Optional otherwise. |
-|  [fare_transfer_rules.txt](#faretransferrulestxt)  | **Conditionally Forbidden** | Fare rules for transfers between legs of travel.<br><br>Along with fare_leg_rules.txt, file fare_transfer_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_transfer_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](farerulestxt) or [fare_attributes.txt](fareattributestxt) are defined.<br>- Optional otherwise. |
+|  [fare_attributes.txt](#fare_attributestxt)  | **Conditionally Forbidden** | Fare information for a transit agency's routes.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](fare_leg_rulestxt) is defined.<br>- Optional otherwise. |
+|  [fare_rules.txt](#fare_rulestxt)  | **Conditionally Forbidden** | Rules to apply fares for itineraries.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](fare_leg_rulestxt) is defined.<br>- Optional otherwise. |
+|  [fare_leg_rules.txt](#fare_leg_rulestxt)  | **Conditionally Forbidden** | Fare rules for individual legs of travel.<br><br>File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](fare_rulestxt) or [fare_attributes.txt](fare_attributestxt) are defined.<br>- Optional otherwise. |
+|  [fare_transfer_rules.txt](#fare_transfer_rulestxt)  | **Conditionally Forbidden** | Fare rules for transfers between legs of travel.<br><br>Along with fare_leg_rules.txt, file fare_transfer_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_transfer_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](fare_rulestxt) or [fare_attributes.txt](fare_attributestxt) are defined.<br>- Optional otherwise. |
 |  [areas.txt](areastxt) | Optional | Area grouping of locations. |
 |  [shapes.txt](#shapestxt)  | Optional | Rules for mapping vehicle travel paths, sometimes referred to as route alignments. |
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for headway-based service or a compressed representation of fixed-schedule service. |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -20,6 +20,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [fare\_attributes.txt](#fare_attributestxt)
     -   [fare\_rules.txt](#fare_rulestxt)
     -   [fare\_leg\_rules.txt](#farelegrulestxt)
+    -   [areas.txt](areastxt)
     -   [shapes.txt](#shapestxt)
     -   [frequencies.txt](#frequenciestxt)
     -   [transfers.txt](#transferstxt)
@@ -95,6 +96,7 @@ This specification defines the following files:
 |  [fare_attributes.txt](#fare_attributestxt)  | **Conditionally Forbidden** | Fare information for a transit agency's routes.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
 |  [fare_rules.txt](#fare_rulestxt)  | **Conditionally Forbidden** | Rules to apply fares for itineraries.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
 |  [fare_leg_rules.txt](#farelegrulestxt)  | **Conditionally Forbidden** | Fare rules for individual legs of travel.<br><br>File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](farerulestxt) or [fare_attributes.txt](fareattributestxt) are defined.<br>- Optional otherwise. |
+|  [areas.txt](areastxt) | Optional | Area grouping of locations. |
 |  [shapes.txt](#shapestxt)  | Optional | Rules for mapping vehicle travel paths, sometimes referred to as route alignments. |
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for headway-based service or a compressed representation of fixed-schedule service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
@@ -160,6 +162,7 @@ File: **Required**
 |  `wheelchair_boarding` | Enum | Optional | Indicates whether wheelchair boardings are possible from the location. Valid options are: <br><br>For parentless stops:<br>`0` or empty - No accessibility information for the stop.<br>`1` - Some vehicles at this stop can be boarded by a rider in a wheelchair.<br>`2` - Wheelchair boarding is not possible at this stop. <br><br>For child stops: <br>`0` or empty - Stop will inherit its `wheelchair_boarding` behavior from the parent station, if specified in the parent.<br>`1` - There exists some accessible path from outside the station to the specific stop/platform.<br>`2` - There exists no accessible path from outside the station to the specific stop/platform.<br><br> For station entrances/exits: <br>`0` or empty - Station entrance will inherit its `wheelchair_boarding` behavior from the parent station, if specified for the parent.<br>`1` - Station entrance is wheelchair accessible.<br>`2` - No accessible path from station entrance to stops/platforms. |
 |  `level_id` | ID referencing `levels.level_id` | Optional | Level of the location. The same level may be used by multiple unlinked stations.|
 |  `platform_code` | Text | Optional | Platform identifier for a platform stop (a stop belonging to a station). This should be just the platform identifier (eg. "G" or "3"). Words like “platform” or "track" (or the feed’s language-specific equivalent) should not be included. This allows feed consumers to more easily internationalize and localize the platform identifier into other languages. |
+| `area_id` | ID referencing `areas.area_id` | Optional | Identifies an area grouping of locations. Multiple rows in `stops.txt` may have the same `area_id`. |
 
 ### routes.txt
 
@@ -312,13 +315,26 @@ Fares in `fare_leg_rules.txt` are queried by filtering fields until a fare cost 
 
 It is recommended that consumers filter `fare_leg_rules.txt` by the fields that define the characteristics of travel as outputted from trip planning software. This would give the immediate capability to display the cost of a leg from within a trip planner. The fields in `fare_leg_rules.txt` that define characteristics of travel are:
 - `fare_leg_rules.network_id`
-
+- `fare_leg_rules.from_area_id`
+- `fare_leg_rules.to_area_id`
+- `fare_leg_rules.is_symmetrical`
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
 | `network_id` | ID referencing `routes.network_id` | Optional | Identifies a route network that applies for the fare leg rule.<br><br>If there are no matching `fare_leg_rules.network_id` values to the `network_id` being filtered, empty `fare_leg_rules.network_id` will be matched by default. |
+| `from_area_id` | ID referencing `areas.area_id` | Optional | Identifies a departure area.<br><br>If there are no matching `fare_leg_rules.from_area_id` values to the `area_id` being filtered, empty `fare_leg_rules.from_area_id` will be matched by default. |
+| `to_area_id` | ID referencing `areas.area_id` | Optional | Identifies an arrival area.<br><br>If there are no matching `fare_leg_rules.to_area_id` values to the `area_id` being filtered, empty `fare_leg_rules.from_area_id` will be matched by default. |
+| `is_symmetrical` | Enum | **Conditionally Required** | Indicates whether the fare leg rule may be applied for `fare_leg_rules.from_area_id` to `fare_leg_rules.to_area_id` as well as for `fare_leg_rules.to_area_id` to `fare_leg_rules.from_area_id`.<br><br>Valid options are:<br>`0` - Not symmetrical.<br>`1` - Symmetrical.<br><br>Conditionally Required:<br><br>- **Required** if either `fare_leg_rules.from_area_id` or `fare_leg_rules.to_area_id` are defined.<br>- **Forbidden** otherwise. |
 | `amount` | Non-negative currency amount | Optional | The cost of the fare for the leg. |
 | `currency` | Currency code | **Conditionally Required** | The currency of the fare for the leg.<br><br>Conditionally Required:<br>- **Required** if `fare_leg_rules.amount` is defined.<br>- **Forbidden** otherwise. |
+
+## areas.txt
+
+File: **Optional**
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+| `area_id` | ID | **Required** | Identifies an area. |
 
 ### shapes.txt
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -19,6 +19,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [calendar\_dates.txt](#calendar_datestxt)
     -   [fare\_attributes.txt](#fare_attributestxt)
     -   [fare\_rules.txt](#fare_rulestxt)
+    -   [fare\_leg\_rules.txt](#farelegrulestxt)
     -   [shapes.txt](#shapestxt)
     -   [frequencies.txt](#frequenciestxt)
     -   [transfers.txt](#transferstxt)
@@ -48,11 +49,13 @@ Presence conditions applicable to fields and files:
 * **Required** - The field or file must be included in the dataset and contain a valid value for each record.
 * **Optional** - The field or file may be omitted from the dataset.
 * **Conditionally Required** - The field or file must be included under conditions outlined in the field or file description.
+* **Conditionally Forbidden** - The field or file must not be included under conditions outlined in the field or file description.
 
 ### Field Types
 
 - **Color** - A color encoded as a six-digit hexadecimal number. Refer to [https://htmlcolorcodes.com](https://htmlcolorcodes.com) to generate a valid value (the leading "#" must not be included). <br> *Example: `FFFFFF` for white, `000000` for black or `0039A6` for the A,C,E lines in NYMTA.*
 - **Currency code** - An ISO 4217 alphabetical currency code. For the list of current currency, refer to [https://en.wikipedia.org/wiki/ISO_4217#Active\_codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes). <br> *Example: `CAD` for Canadian dollars, `EUR` for euros or `JPY` for Japanese yen.*
+- **Currency amount** - A decimal value indicating a currency amount. The number of decimal places is specified by [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) for the accompanying Currency code. All financial calculations should be processed as decimal, currency, or another equivalent type suitable for financial calculations depending on the programming language used to consume data. Processing currency amounts as float is discouraged due to gains or losses of money during calculations.
 - **Date** - Service day in the YYYYMMDD format. Since time within a service day may be above 24:00:00, a service day may contain information for the subsequent day(s). <br> *Example: `20180913` for September 13th, 2018.*
 - **Email** - An email address. <br> *Example: `example@example.com`*
 - **Enum** - An option from a set of predefined constants defined in the "Description" column. <br> *Example: The `route_type` field contains a `0` for tram, a `1` for subway...*
@@ -89,8 +92,9 @@ This specification defines the following files:
 |  [stop_times.txt](#stop_timestxt)  | **Required** | Times that a vehicle arrives at and departs from stops for each trip. |
 |  [calendar.txt](#calendartxt)  | **Conditionally Required** | Service dates specified using a weekly schedule with start and end dates. <br><br>Conditionally Required:<br> - **Required** unless all dates of service are defined in [calendar_dates.txt](#calendar_datestxt).<br> - Optional otherwise. |
 |  [calendar_dates.txt](#calendar_datestxt)  | **Conditionally Required** | Exceptions for the services defined in the [calendar.txt](#calendartxt). <br><br>Conditionally Required:<br> - **Required** if [calendar.txt](#calendartxt) is omitted. In which case [calendar_dates.txt](#calendar_datestxt) must contain all dates of service. <br> - Optional otherwise. |
-|  [fare_attributes.txt](#fare_attributestxt)  | Optional | Fare information for a transit agency's routes. |
-|  [fare_rules.txt](#fare_rulestxt)  | Optional | Rules to apply fares for itineraries. |
+|  [fare_attributes.txt](#fare_attributestxt)  | **Conditionally Forbidden** | Fare information for a transit agency's routes.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
+|  [fare_rules.txt](#fare_rulestxt)  | **Conditionally Forbidden** | Rules to apply fares for itineraries.<br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_leg_rules.txt](farelegrulestxt) is defined.<br>- Optional otherwise. |
+|  [fare_leg_rules.txt](#farelegrulestxt)  | **Conditionally Forbidden** | Fare rules for individual legs of travel.<br><br>File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt. <br><br>Conditionally Forbidden:<br>- **Forbidden** if [fare_rules.txt](farerulestxt) or [fare_attributes.txt](fareattributestxt) are defined.<br>- Optional otherwise. |
 |  [shapes.txt](#shapestxt)  | Optional | Rules for mapping vehicle travel paths, sometimes referred to as route alignments. |
 |  [frequencies.txt](#frequenciestxt)  | Optional | Headway (time between trips) for headway-based service or a compressed representation of fixed-schedule service. |
 |  [transfers.txt](#transferstxt)  | Optional | Rules for making connections at transfer points between routes. |
@@ -263,7 +267,7 @@ The [calendar_dates.txt](#calendar_datestxt) table explicitly activates or disab
 
 ### fare_attributes.txt
 
-File: **Optional**
+File: **Conditionally Forbidden**
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
@@ -277,7 +281,7 @@ File: **Optional**
 
 ### fare_rules.txt
 
-File: **Optional**
+File: **Conditionally Forbidden**
 
 The [fare_rules.txt](#farerulestxt) table specifies how fares in [fare_attributes.txt](#fare_attributestxt) apply to an itinerary. Most fare structures use some combination of the following rules:
 
@@ -294,6 +298,19 @@ For examples that demonstrate how to specify a fare structure with [fare_rules.t
 |  `origin_id` | ID referencing `stops.zone_id` | Optional | Identifies an origin zone. If a fare class has multiple origin zones, create a record in [fare_rules.txt](#fare_rules.txt) for each `origin_id`.<hr>*Example: If fare class "b" is valid for all travel originating from either zone "2" or zone "8", the [fare_rules.txt](#fare_rules.txt) file would contain these records for the fare class:* <br> `fare_id,...,origin_id` <br> `b,...,2`  <br> `b,...,8` |
 |  `destination_id` | ID referencing `stops.zone_id` | Optional | Identifies a destination zone. If a fare class has multiple destination zones, create a record in [fare_rules.txt](#fare_rules.txt) for each `destination_id`.<hr>*Example: The `origin_id` and `destination_id` fields could be used together to specify that fare class "b" is valid for travel between zones 3 and 4, and for travel between zones 3 and 5, the [fare_rules.txt](#fare_rules.txt) file would contain these records for the fare class:* <br>`fare_id,...,origin_id,destination_id` <br>`b,...,3,4`<br> `b,...,3,5` |
 |  `contains_id` | ID referencing `stops.zone_id` | Optional | Identifies the zones that a rider will enter while using a given fare class. Used in some systems to calculate correct fare class. <hr>*Example: If fare class "c" is associated with all travel on the GRT route that passes through zones 5, 6, and 7 the [fare_rules.txt](#fare_rules.txt) would contain these records:* <br> `fare_id,route_id,...,contains_id` <br>  `c,GRT,...,5` <br>`c,GRT,...,6` <br>`c,GRT,...,7` <br> *Because all `contains_id` zones must be matched for the fare to apply, an itinerary that passes through zones 5 and 6 but not zone 7 would not have fare class "c". For more detail, see [https://code.google.com/p/googletransitdatafeed/wiki/FareExamples](https://code.google.com/p/googletransitdatafeed/wiki/FareExamples) in the GoogleTransitDataFeed project wiki.* |
+
+## fare_leg_rules.txt
+
+File: **Conditionally Forbidden**
+
+Fare rules for individual legs of travel. 
+
+File fare_leg_rules.txt provides a more detailed method for modeling fare structures. As such, the use of fare_leg_rules.txt is entirely seperate from files fare_attributes.txt and fare_rules.txt.
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+| `amount` | Non-negative currency amount | Optional | The cost of the fare for the leg. |
+| `currency` | Currency code | **Conditionally Required** | The currency of the fare for the leg.<br><br>Conditionally Required:<br>- **Required** if `fare_leg_rules.amount` is defined.<br>- **Forbidden** otherwise. |
 
 ### shapes.txt
 


### PR DESCRIPTION
Hi Everyone,   we ([MobilityData](https://mobilitydata.org/)) wanted to draw some attention to the base implementation of [GTFS-Fares v2](http://bit.ly/gtfs-fares). 

  As discussed in #252, GTFS-Fares v2 is a proposal that models simple and complex fare structures in GTFS where the current files `fare_attributes.txt` and `fare_rules.txt` lack.   
  
  This PR presents the adoptable fields of GTFS-Fares v2, where at least 1 producer and 1 consumer have implementation. As documented [here](https://docs.google.com/spreadsheets/d/1jpKjz6MbCD2XPhmIP11EDi-P2jMh7x2k-oHS-pLf2vI/edit#gid=890539561), [Interline](https://www.interline.io/blog/mtc-regional-gtfs-feed-additions/#using-fares-and-transfer-discounts), [Maryland DOT](https://www.mta.maryland.gov/developer-resources), and [Cal-ITP](https://docs.google.com/document/d/1lLSok5YZ3Z7jBuzPGeVMvl3r9PFQvJ0yul6wovJqsGY/edit) (for 50+ agencies) have produced subsets of GTFS-Fares v2, with [Transit app](https://transitapp.com/) consuming.  
  
  Posted as separate commits to ease comprehension, the features in this PR include:
- Fare costs for individual legs of travel
- Fares for routes and networks of routes
- Fares for area location groups
- Detailed transfer rules between legs of travel

The complete suite of features in GTFS-Fares v2 include:
- Timeframes
- Distance-based fares
- Fare products (i.e., passes)
- Fare containers (i.e., magnetic cards)
- Rider categories
- Fare capping
- WIP: Fare point-of-sale and payment methods 

The [#gtfs-fares](https://docs.google.com/forms/d/e/1FAIpQLSczZbZB9ql_Xl-1uBtmvYmA0fwfm1UX92SyWAdkuMEDfxac5w/viewform) Slack channel has been a great resource and community for debugging, building documentation, and working through problems. I highly recommend anyone interested to join. 

For other questions/concerns, don’t hesitate to reach out to specificiations@mobilitydata.org.

Looking forward to feedback and contribution on this proposal. Thanks!