### PR TITLE
Repository admin: stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 issues:
   daysUntilStale: 365
-  daysUntilClose: 7
+  daysUntilClose: 14
   staleLabel: stale
   markComment: >
     This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
Currently, [stale.yml](https://github.com/google/transit/blob/master/.github/stale.yml) automates the closing of stale pull requests on this repository as codified by the specification amendment process:
> Any pull request remaining inactive for 30 calendar days will be closed. When a pull request is closed, the corresponding proposal is considered abandoned. The advocate may reopen the pull request at any time if they wish to continue or maintain the conversation.

I think we need something similar to manage stale issues in order to bring momentum and have a less noisy space for focused discussions. 

I'm proposing 365 days until an issue is stale, automatically closing 7 days later. 

Does this seem reasonable? Looking forward to any thoughts from the community.