### PR TITLE
GTFS-Occupancies unmerged

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -388,9 +388,9 @@ File: **Optional**
 
 Usual or expected in-vehicle occupancy levels.
 
-For describing historical average occupancies at least 4 weeks of occupancy data should be averaged across each unique day of the week, valid for up to 2 weeks thereafter in `occupancies.txt`.
+Methods for occupancy forecasting used to populated `occupancies.txt` are not strictly specified. Beyond the guidelines given below, it is the responsibility of data producers to ensure that the data provided are meaningful.
 
-Methods for occupancy forecasting used to populated `occupancies.txt` are not strictly specified. Beyond the guidelines given above, it is the responsibility of data producers to ensure that the data provided are meaningful. 
+For describing historical average occupancies, it is recommended that at least 4 weeks of occupancy data be averaged across each unique day of the week, and valid for up to 2 weeks thereafter in `occupancies.txt`.
 
 | Field Name | Type | Required | Description |
 | ----- | ----- | ----- | ----- |


### PR DESCRIPTION
~~This pull request is a continuation of discussions at #240.~~

~~GTFS-Occupancies is an extension proposal to describe usual or expected vehicle occupancy levels in GTFS Schedule.~~

~~As occupancies can currently be described in GTFS Realtime using [`occupancy_status`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-occupancystatus) and [`occupancy_percentage`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicleposition), GTFS-Occupancies aims to complement the availability of crowdedness information by providing static predictions for future trips based on historical trends, which can help riders plan trips based on their crowdedness preferences and comfortability.~~

~~To be resolved:~~
~~- Officializing an occupancy indicator in GTFS Realtime: Currently, both `OccupancyStatus` and `occupancy_percentage` are experimental. Ideally, we want consistency between static and realtime occupancy indicators. Whichever becomes official in GTFS Realtime will be the one used here.~~
~~- Elaborating GTFS-Occupancies to support frequency-based service. Some thinking on this [here](https://github.com/google/transit/pull/240#discussion_r713393734).~~

~~TfNSW has published a dataset: https://github.com/google/transit/pull/240#issuecomment-921526701.~~