### PR TITLE
Announcing opening and closing of votes on mailing lists

### DIFF
--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -28,6 +28,7 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
 1. The advocate can call for a vote on a version of the proposal at any point in time following the initial 7-day interval required for discussion.
     - Before calling for a vote, at least one GTFS-realtime producer and one GTFS-realtime consumer should implement the proposed change. It is expected that the GTFS-realtime producer(s) include the change in a public-facing GTFS-realtime feed and provide a link to that data within the pull request comments, and that the GTFS-realtime consumer(s) provides a link in the pull request comments to an application that is utilizing the change in a non-trivial manner (i.e, it is supporting new or improved functionality).
     - When calling for a vote, the advocate should clearly state whether the vote is for official adoption of the field into the spec or for an experimental field.
+    - Opening and closing of votes must be announced on the GTFS Realtime mailing list.
 1. Vote lasts the minimum period sufficient to cover 7 full calendar days and 5 full Swiss business days. Vote ends at 23:59:59 UTC.
   	- The advocate should announce the specific end time at the start of the vote.
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).

--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -28,13 +28,13 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
 1. The advocate can call for a vote on a version of the proposal at any point in time following the initial 7-day interval required for discussion.
     - Before calling for a vote, at least one GTFS-realtime producer and one GTFS-realtime consumer should implement the proposed change. It is expected that the GTFS-realtime producer(s) include the change in a public-facing GTFS-realtime feed and provide a link to that data within the pull request comments, and that the GTFS-realtime consumer(s) provides a link in the pull request comments to an application that is utilizing the change in a non-trivial manner (i.e, it is supporting new or improved functionality).
     - When calling for a vote, the advocate should clearly state whether the vote is for official adoption of the field into the spec or for an experimental field.
-    - Opening and closing of votes must be announced on the GTFS Realtime mailing list.
 1. Vote lasts the minimum period sufficient to cover 7 full calendar days and 5 full Swiss business days. Vote ends at 23:59:59 UTC.
   	- The advocate should announce the specific end time at the start of the vote.
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   	- Votes before the start of the voting period are not considered.
+    - Opening and closing of votes must be announced on the GTFS Realtime mailing list.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   	- Votes against shall be motivated, and ideally provide actionable feedback.

--- a/gtfs-realtime/CHANGES.md
+++ b/gtfs-realtime/CHANGES.md
@@ -34,12 +34,12 @@ When a producer or consumer is interested in adding a new field to the GTFS Real
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   	- Votes before the start of the voting period are not considered.
-    - Opening and closing of votes must be announced on the GTFS Realtime mailing list.
+    - Opening and closing of votes must be announced on the [GTFS Realtime mailing list](https://groups.google.com/forum/#!forum/gtfs-realtime).
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   	- Votes against shall be motivated, and ideally provide actionable feedback.
   	- If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
-    Either decision of the advocate must be announced in the mailing list.
+    Either decision of the advocate must be announced in the [GTFS Realtime mailing list](https://groups.google.com/forum/#!forum/gtfs-realtime).
   	- If the advocate continues the work on proposal then a new vote can be called for at any point in time.
 1. Any pull request remaining inactive for 30 calendar days will be closed. When a pull request is closed, the corresponding proposal is considered abandoned. The advocate may reopen the pull request at any time if they wish to continue or maintain the conversation. 
  	- Note that the advocate may choose to implement the feature as an [custom extension](#extensions) instead of part of the official spec.

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -13,6 +13,7 @@ The official specification, reference and documentation are written in English. 
   	- At any point in time the advocate can claim proposal abandoned.
 1. The advocate can call for a vote on a version of the proposal at any point in time following the initial 7-day interval required for discussion.
   	- Before calling for a vote, at least one GTFS producer and one GTFS consumer should implement the proposed change.  It is expected that the GTFS producer(s) include the change in a public-facing GTFS feed and provide a link to that data within the pull request comments, and that the GTFS consumer(s) provides a link in the pull request comments to an application that is utilizing the change in a non-trivial manner (i.e, it is supporting new or improved functionality).
+	- Opening and closing of votes must be announced on the GTFS Changes mailing list.
 1. Vote lasts the minimum period sufficient to cover 7 full calendar days and 5 full Swiss business days. Vote ends at 23:59:59 UTC.
   	- The advocate should announce the specific end time at the start of the vote.
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -19,12 +19,12 @@ The official specification, reference and documentation are written in English. 
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   	- Votes before the start of the voting period are not considered.
-	- Opening and closing of votes must be announced on the GTFS Changes mailing list.
+	- Opening and closing of votes must be announced on the [GTFS Changes mailing list](https://groups.google.com/forum/#!forum/gtfs-changes).
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   	- Votes against shall be motivated, and ideally provide actionable feedback.
   	- If the vote has failed, then the advocate may choose to continue work on the proposal, or to abandon the proposal.
-    Either decision of the advocate must be announced in the mailing list.
+    Either decision of the advocate must be announced in the [GTFS Changes mailing list](https://groups.google.com/forum/#!forum/gtfs-changes).
   	- If the advocate continues the work on proposal then a new vote can be called for at any point in time.
 1. Any pull request remaining inactive for 30 calendar days will be closed. When a pull request is closed, the corresponding proposal is considered abandoned. The advocate may reopen the pull request at any time if they wish to continue or maintain the conversation.
 1. If the proposal is accepted:

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -13,13 +13,13 @@ The official specification, reference and documentation are written in English. 
   	- At any point in time the advocate can claim proposal abandoned.
 1. The advocate can call for a vote on a version of the proposal at any point in time following the initial 7-day interval required for discussion.
   	- Before calling for a vote, at least one GTFS producer and one GTFS consumer should implement the proposed change.  It is expected that the GTFS producer(s) include the change in a public-facing GTFS feed and provide a link to that data within the pull request comments, and that the GTFS consumer(s) provides a link in the pull request comments to an application that is utilizing the change in a non-trivial manner (i.e, it is supporting new or improved functionality).
-	- Opening and closing of votes must be announced on the GTFS Changes mailing list.
 1. Vote lasts the minimum period sufficient to cover 7 full calendar days and 5 full Swiss business days. Vote ends at 23:59:59 UTC.
   	- The advocate should announce the specific end time at the start of the vote.
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.
     If a voter changes her vote, it is recommended to do it by updating the original vote comment by striking through the vote and writing the new vote.
   	- Votes before the start of the voting period are not considered.
+	- Opening and closing of votes must be announced on the GTFS Changes mailing list.
 1. The proposal is accepted if there is a unanimous consensus yes with at least 3 votes.
   	- The proposer's vote does not count towards the 3 vote total. For example, if Proposer X creates a pull request and votes yes, and User Y and Z vote yes, this is counted as 2 total yes votes.
   	- Votes against shall be motivated, and ideally provide actionable feedback.


### PR DESCRIPTION
As discussed in #96, this PR specifies in the Specification Amendment Process that opening and closing of votes must be announced on the appropriate mailing lists for GTFS and GTFS Realtime.