### PR TITLE
Clarification: Copy guiding principle from GTFS Realtime to GTFS

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -42,6 +42,9 @@ We chose CSV as the basis for the specification because it's easy to view and ed
 #### Feeds should be easy to parse
 Feed readers should be able to extract the information they're looking for with as little work as possible. Changes and additions to the feed should be as broadly useful as possible, to minimize the number of code paths that readers of the feed need to implement. (However, making creation easier should be given precedence, since there will ultimately be more feed publishers than feed readers.)
 
+#### The spec is about passenger information
+GTFS is primarily concerned with passenger information. That is, the spec should include information that can help power tools for riders, first and foremost. There is potentially a large amount of operations-oriented information that transit agencies might want to transmit internally between systems. GTFS is not intended for that purpose and there are potentially other operations-oriented data-standards that may be more appropriate.
+
 #### Changes to the spec should be backwards-compatible
 When adding features to the specification, we want to avoid making changes that will make existing feeds invalid. We don't want to create more work for existing feed publishers until they want to add capabilities to their feeds. Also, whenever possible, we want existing parsers to be able to continue to read the older parts of newer feeds.
 


### PR DESCRIPTION
A question recently came up - "is GTFS focused on passenger information?"

I tried to find the reference in the spec that says this, but couldn't.

Then I realized that, for some reason, this guiding principle is listed under GTFS Realtime but not GTFS.

[GTFS Realtime CHANGES.md](https://github.com/google/transit/blob/master/gtfs-realtime/CHANGES.md#the-spec-is-about-passenger-information) says that this principle applies to both GTFS and GTFS Realtime:

>#### The spec is about passenger information.
>Like GTFS before it, GTFS Realtime is primarily concerned with passenger information. That is, the spec should include information that can help power tools for riders, first and foremost. There is potentially a large amount of operations-oriented information that transit agencies might want to transmit internally between systems. GTFS Realtime is not intended for that purpose and there are potentially other operations-oriented data-standards that may be more appropriate.

This pull request copies the same guiding principle from GTFS Realtime to GTFS and updates the wording accordingly.

I think there is a legitimate debate over whether this should still be a guiding principle for GTFS, although I'd prefer to have that discussion in a separate issue. 

IMHO it's pretty clear from the existing text that this guiding principle is intended for GTFS as well, and this changes focuses on making that clear to readers of the GTFS docs that don't review the GTFS Realtime documentation.