### PR TITLE
translations.txt: translation should not be a primary key

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -436,7 +436,7 @@ Describes levels in a station. Useful in conjunction with `pathways.txt`, and is
 
 File: **Optional**
 
-Primary key (`*`)
+Primary key (`table_name`, `field_name`, `language`, `record_id`, `record_sub_id`, `field_value`)
 
 In regions that have multiple official languages, transit agencies/operators typically have language-specific names and web pages. In order to best serve riders in those regions, it is useful for the dataset to include these language-dependent values.
 


### PR DESCRIPTION
## Current issue
The primary key for translations.txt is `*`, meaning all fields are part of the primary key. However, this allows two identical records to be translated in different ways for one language, with no reasoning behind which translation should take precedence. It seems that this is in fact an error, and that the translation field should not be part of the primary key of the table. Example:

routes.txt
```
route_id,route_short_name
route_id_1,subway
```
translations.txt
```
table_name,field_name,language,translation,record_id,record_sub_id,field_value
routes,route_short_name,fr,métro,route_id_1,,
routes,route_short_name,fr,train,route_id_1,,
```

## Solution in this PR
The fields (`table_name`, `field_name`, `language`, `record_id`, `record_sub_id`, `field_value`) are the primary keys of translations.txt.