### PR TITLE
translations.txt: specify which translation takes precedence over another

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -458,6 +458,8 @@ Primary key (none)
 
 The file contains information about the dataset itself, rather than the services that the dataset describes. In some cases, the publisher of the dataset is a different entity than any of the agencies.
 
+If both referencing methods (`record_id`, `record_sub_id`) and `field_value` are used to translate the same value in 2 different rows, the translation provided with (`record_id`, `record_sub_id`) takes precedence.
+
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
 |  `feed_publisher_name` | Text | **Required** | Full name of the organization that publishes the dataset. This may be the same as one of the `agency.agency_name` values. |


### PR DESCRIPTION
## Current issue

Translations can be defined in two ways using translations.txt:
- By referring to a particular row using record_id and record_sub_id;
- By referring to a particular value using field_value;

The specification does not forbid translating the same value twice, using both referencing methods. In which case, there is no stated logic over which translation should take preference. This leads to a situation where the data consumer needs to make a discretionary choice, behavior that is not desired. Example:

routes.txt
```
route_id,route_short_name
route_id_1,subway
```
translations.txt
```
table_name,field_name,language,translation,record_id,record_sub_id,field_value
routes,route_short_name,fr,métro,route_id_1,,
routes,route_short_name,fr,train,,,subway
```

## Solution in this PR
The translation made with the referencing method (`record_id`, `record_sub_id`) takes precedence.