### PR TITLE
Add fare containers to reference.md

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -19,6 +19,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [calendar\_dates.txt](#calendar_datestxt)
     -   [fare\_attributes.txt](#fare_attributestxt)
     -   [fare\_rules.txt](#fare_rulestxt)
+    -   [fare\_containers.txt](#fare_containerstxt)         
     -   [fare\_products.txt](#fare_productstxt) 
     -   [fare\_leg\_rules.txt](#fare_leg_rulestxt)
     -   [fare\_transfer\_rules.txt](#fare_transfer_rulestxt)
@@ -343,6 +344,23 @@ For examples that demonstrate how to specify a fare structure with [fare_rules.t
 |  `destination_id` | Foreign ID referencing `stops.zone_id` | Optional | Identifies a destination zone. If a fare class has multiple destination zones, create a record in [fare_rules.txt](#fare_rules.txt) for each `destination_id`.<hr>*Example: The `origin_id` and `destination_id` fields could be used together to specify that fare class "b" is valid for travel between zones 3 and 4, and for travel between zones 3 and 5, the [fare_rules.txt](#fare_rules.txt) file would contain these records for the fare class:* <br>`fare_id,...,origin_id,destination_id` <br>`b,...,3,4`<br> `b,...,3,5` |
 |  `contains_id` | Foreign ID referencing `stops.zone_id` | Optional | Identifies the zones that a rider will enter while using a given fare class. Used in some systems to calculate correct fare class. <hr>*Example: If fare class "c" is associated with all travel on the GRT route that passes through zones 5, 6, and 7 the [fare_rules.txt](#fare_rules.txt) would contain these records:* <br> `fare_id,route_id,...,contains_id` <br>  `c,GRT,...,5` <br>`c,GRT,...,6` <br>`c,GRT,...,7` <br> *Because all `contains_id` zones must be matched for the fare to apply, an itinerary that passes through zones 5 and 6 but not zone 7 would not have fare class "c". For more detail, see [https://code.google.com/p/googletransitdatafeed/wiki/FareExamples](https://code.google.com/p/googletransitdatafeed/wiki/FareExamples) in the GoogleTransitDataFeed project wiki.* |
 
+### fare_containers.txt
+
+To describe fare containers, which are used to load fare products such as tickets, passes, and discounted fares.
+
+File: **Optional** 
+
+Primary Key (`fare_container_id`)
+
+|  Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+|  `fare_container_id` | Unique ID | **Required** | Identifies a fare container. |
+|  `fare_container_name` | Text | Optional | The name of the fare container as displayed to riders. |
+|  `amount` | Non-negative currency amount | Optional | The cost of the fare container. |
+|  `minimum_initial_purchase` | Non-negative currency amount | Optional | The cost of the minimum initial purchase required on the fare container. |
+|  `currency` | Currency code | **Conditionally Required** | The currency of `fare_containers.amount` or `fare_containers.minimum_initial_purchase`. <br/> Conditionally Required: <br/> - **Required** if `fare_containers.amount` or `fare_containers.minimum_initial_purchase` are defined. <br/> - **Forbidden** if `fare_containers.amount` and `fare_containers.minimum_initial_purchase` are empty. |
+
+
 ### fare_products.txt
 
 File: **Optional**
@@ -357,6 +375,8 @@ To describe the different types of tickets or fares that can be purchased by rid
 | `fare_product_name` | Text | Optional | The name of the fare product as displayed to riders. |
 | `amount` | Currency amount | **Required** | The cost of the fare product. May be negative to represent transfer discounts. May be zero to represent a fare product that is free.|
 | `currency` | Currency code | **Required** | The currency of the cost of the fare product. |
+|  `fare_container_id` | Foreign ID referencing `fare_containers.fare_container_id` | Optional |  Identifies the fare container that the fare product can be loaded on. If this field is left blank, the record corresponds to a fare product that is purchased outside of a fare container. |
+
 
 ### fare_leg_rules.txt
 


### PR DESCRIPTION
Hi everyone,   MobilityData is moving forward with the second iteration of GTFS-Fares v2, for more information about the overall plan, you can check [this issue](https://github.com/google/transit/issues/341). 

This pull request covers Fare Containers, which is a section of the entire [GTFS-Fares v2 proposal](https://docs.google.com/document/d/19j-f-wZ5C_kYXmkLBye1g42U-kvfSVgYLkkG5oyBauY/edit#heading=h.mhjuwqk2h5r3). 

Fare containers correspond to cards or mobile applications that are used to load and use fares. In many cases, fares loaded on a fare container are cheaper than fares purchased as individual tickets outside a fare container. 

The changes in this pull request are:
- Add new file; `fare_containers.txt`, to define new fare containers.
- Extend `fare_products.txt` with `fare_container_id` to assign fare products to fare containers and to define the price of a fare if a fare container is used to pay.

The behaviour of `fare_leg_rules.txt` and `fare_transfer_rules.txt` is unchanged as the cost of a fare leg or a transfer is tied to a fare product. The modelling of the cost of a one-way ticket purchased as a ticket vs. loaded on a fare container factors in `fare_products.txt`.

**_Here's a quick example:_**
- A fare container costs 5 CAD.
- A fare is 3 CAD, however, if riders load the fare on their fare container and pay with it, a fare is 2.95 CAD.
- Riders can transfer once - in a period of one hour - if they do not have a fare container, they will pay 0.05 CAD to transfer, however, if they transfer using their fare container, the transfer is free.

Define a fare container in `fare_containers.txt`
|fare_container_id  | amount | currency|
|--|--|--|
| container | 5 | CAD|

Define the fare structure (paying for a fare with and without the fare container) in `fare_products.txt`
|fare_product_id|fare_container_id  | amount | currency|
|--|--|--|--|
| single_leg |  | 3 | CAD|
| single_leg | container | 2.95 | CAD|
| transfer_cost |  | 0.05 | CAD|
| transfer_cost | container | 0 | CAD|

Define fare legs using `fare_leg_rules.txt`
|leg_group_id|from_area_id|to_area_id | network_id| fare_product_id | 
|--|--|--|--|--|
|leg1| zoneA | zoneB | bus | single_leg|

Define transfer rules using `fare_transfer_rules.txt`
|from_leg_group_id|to_leg_group_id|transfer_count | duration_limit| duration_limit_type |fare_transfer_type|fare_product_id| 
|--|--|--|--|--|--|--|
|leg1|leg1|1 | 3600| 0 |0|transfer_cost| 

Data consumer: [Apple](https://www.apple.com/)
Data producer:   [Interline](https://www.interline.io/)

Please go through the changes and share your thoughts here!
Looking forward to feedback and contribution on this proposal. 

For other questions/concerns, don’t hesitate to reach out to [specifications@mobilitydata.org](mailto:specifications@mobilitydata.org).