### PR TITLE
Revert change that made `fare_rules.txt` conditionally required.

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -108,7 +108,7 @@ This specification defines the following files:
 |  [calendar.txt](#calendartxt)  | **Conditionally Required** | Service dates specified using a weekly schedule with start and end dates. <br><br>Conditionally Required:<br> - **Required** unless all dates of service are defined in [calendar_dates.txt](#calendar_datestxt).<br> - Optional otherwise. |
 |  [calendar_dates.txt](#calendar_datestxt)  | **Conditionally Required** | Exceptions for the services defined in the [calendar.txt](#calendartxt). <br><br>Conditionally Required:<br> - **Required** if [calendar.txt](#calendartxt) is omitted. In which case [calendar_dates.txt](#calendar_datestxt) must contain all dates of service. <br> - Optional otherwise. |
 |  [fare_attributes.txt](#fare_attributestxt)  | Optional | Fare information for a transit agency's routes. |
-|  [fare_rules.txt](#fare_rulestxt)  | **Conditionally Required** | Rules to apply fares for itineraries.<br><br>Conditionally Required:<br>- **Required** if [fare_attributes.txt](#fare_attributestxt) is defined.<br>- **Forbidden** otherwise. |
+|  [fare_rules.txt](#fare_rulestxt) | Optional | Rules to apply fares for itineraries. | 
 |  [fare_products.txt](#fare_productstxt)  | Optional | To describe the different types of tickets or fares that can be purchased by riders.<br><br>File [fare_products.txt](fare_productstxt) describes fare products that are not represented in [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). As such, the use of [fare_products.txt](#fare_productstxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
 |  [fare_leg_rules.txt](#fare_leg_rulestxt)  | Optional | Fare rules for individual legs of travel.<br><br>File [fare_leg_rules.txt](#fare_leg_rulestxt) provides a more detailed method for modeling fare structures. As such, the use of [fare_leg_rules.txt](#fare_leg_rulestxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
 |  [fare_transfer_rules.txt](#fare_transfer_rulestxt)  | Optional | Fare rules for transfers between legs of travel.<br><br>Along with [fare_leg_rules.txt](#fare_leg_rulestxt), file [fare_transfer_rules.txt](#fare_transfer_rulestxt) provides a more detailed method for modeling fare structures. As such, the use of [fare_transfer_rules.txt](#fare_transfer_rulestxt) is entirely separate from files [fare_attributes.txt](#fare_attributestxt) and [fare_rules.txt](#fare_rulestxt). |
@@ -323,7 +323,7 @@ There are two modelling options for describing fares. GTFS-Fares V1 is the legac
 
 ### fare_rules.txt
 
-File: **Conditionally Required**
+File: **Optional**
 
 Primary key (`*`)
 


### PR DESCRIPTION
When the initial Fares v2 base implementation was added to the official spec (#286), it also included some changes for Fares v1.  Specifically, `fare_rules.txt` was now marked as conditionally required if `fare_attributes.txt` is present. I believe this change was a mistake and should be reverted.

It's my understanding that `fare_attributes.txt` has always been allowed with a single entry to indicate a flat fare for all rides.  In this scenario, `fare_rules.txt` is not required.  This behavior was documented on the original [Fare Examples wiki entry](https://web.archive.org/web/20111207224351/https://code.google.com/p/googletransitdatafeed/wiki/FareExamples) and has been (described elsewhere)[https://docs.google.com/document/d/1mK3--o5g4-3cCXaqmch92U63JTwChh0L2VCmcDViIlM/edit#heading=h.1xji1nf0ko4z] as well.  More importantly, I count ~40 feeds in the MobilityDatabase that are currently relying on this behavior.

There was also a comment from @flocsy calling out this behavior in the original PR discussion (https://github.com/google/transit/pull/286#issuecomment-1082480847), but I think it got dropped in the lengthy Fares v2 discussion?

Given all that evidence, my proposal is to revert the language change making `fare_rules.txt` conditionally required.

See also the [related discussion](https://mobilitydata-io.slack.com/archives/C01KL7PR170/p1664918057609029) in the #gtfs-fares slack channel and [related discussion](https://github.com/MobilityData/gtfs-validator/pull/1261#issuecomment-1267465819) for the gtfs-validator.

gtfs-changes announcement: https://groups.google.com/g/gtfs-changes/c/Jn8OIuK6J54/m/RWg9hqwTBQAJ