### PR TITLE
Update CHANGES.md with latest changes

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -53,6 +53,22 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 ### Revision History
 
+#### July 26, 2022
+
+* Added trip-to-trip transfers with in-seat option. See [discussion](https://github.com/google/transit/pull/303)
+
+#### May 17, 2022
+
+* GTFS-Fares v2 base implementation. See [discussion](https://github.com/google/transit/pull/286)
+
+#### Oct 22, 2021
+
+* Added Primary and Foreign ID fields. See [discussion](https://github.com/google/transit/pull/278)
+
+#### Oct 05, 2021
+
+* Added Trip-to-trip and route-to-route transfers. See [discussion](https://github.com/google/transit/pull/284)
+
 #### September 15, 2021
 
 * Allowed fare gates (pathway_mode=6) to be bidirectional. See [discussion](https://github.com/google/transit/pull/276).


### PR DESCRIPTION
It seems like this doc hasn't been updated for a while 🙈.
I think we can add an item in the governance process for the PR advocate to update this file after their PR is merged?

It looks like this list is not exhaustive, it's just an overview of the biggest updates so if we add this item to the governance, we'll need to define what is "big enough" to require an update.