### PR TITLE
gtfs: Update process to change minimum comment period.

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -13,7 +13,7 @@ The official specification, reference and documentation are written in English. 
   	- At any point in time the advocate can claim proposal abandoned.
 1. The advocate can call for a vote on a version of the proposal at any point in time following the initial 7-day interval required for discussion.
   	- Before calling for a vote, at least one GTFS producer and one GTFS consumer should implement the proposed change.  It is expected that the GTFS producer(s) include the change in a public-facing GTFS feed and provide a link to that data within the pull request comments, and that the GTFS consumer(s) provides a link in the pull request comments to an application that is utilizing the change in a non-trivial manner (i.e, it is supporting new or improved functionality).
-1. Vote lasts the minimum period sufficient to cover 7 full calendar days and 5 full Swiss business days. Vote ends at 23:59:59 UTC.
+1. Vote lasts the minimum period sufficient to cover 14 full calendar days. Vote ends at 23:59:59 UTC.
   	- The advocate should announce the specific end time at the start of the vote.
   	- During voting period only editorial changes to the proposal are allowed (typos, wording may change as long as it does not change the meaning).
   	- Anyone is allowed to vote yes/no in a form of comment to the pull request, and votes can be changed until the end of the voting period.


### PR DESCRIPTION
First, the spec maintainers are not as Swiss-centric as they used to be
be.

Second, there is only one Swiss national holiday. The rest are
canton-specific, so the spec was not clear anyway.

Ref: https://groups.google.com/g/gtfs-changes/c/cUIt61d95-Y/m/rBTcndx_AgAJ
