### PR TITLE
Update revision history

### DIFF
--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -53,12 +53,14 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 ### Revision History
 
+#### August 2023
+* Add fare_media_type=1. See [discussion](https://github.com/google/transit/pull/385).
+
 #### July 2023
 * Forbid subfolders in GTFS files. See [discussion](https://github.com/google/transit/pull/379).
 * Added variable fares by time or day. See [discussion](https://github.com/google/transit/pull/357).
 * Clarify implied timezone in stop_times.txt. See [discussion](https://github.com/google/transit/pull/378).
 * Specify stop times shape_dist_traveled must not exceed the trip shape's maximum distance. See [discussion](https://github.com/google/transit/pull/380).
-* Add fare_media_type=1. See [discussion](https://github.com/google/transit/pull/385).
 * Best practices: add recommended presence. See [discussion](https://github.com/google/transit/pull/386).
 
 #### March 14, 2023

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -53,6 +53,10 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 
 ### Revision History
 
+#### July 2023
+* Forbid subfolders in GTFS files. See [discussion](https://github.com/google/transit/pull/379).
+* Added variable fares by time or day. See [discussion](https://github.com/google/transit/pull/357).
+
 #### March 14, 2023
 
 * Added fare media. See [discussion](https://github.com/google/transit/pull/355).

--- a/gtfs/CHANGES.md
+++ b/gtfs/CHANGES.md
@@ -56,6 +56,10 @@ Every new feature adds complexity to the creation and reading of feeds. Therefor
 #### July 2023
 * Forbid subfolders in GTFS files. See [discussion](https://github.com/google/transit/pull/379).
 * Added variable fares by time or day. See [discussion](https://github.com/google/transit/pull/357).
+* Clarify implied timezone in stop_times.txt. See [discussion](https://github.com/google/transit/pull/378).
+* Specify stop times shape_dist_traveled must not exceed the trip shape's maximum distance. See [discussion](https://github.com/google/transit/pull/380).
+* Add fare_media_type=1. See [discussion](https://github.com/google/transit/pull/385).
+* Best practices: add recommended presence. See [discussion](https://github.com/google/transit/pull/386).
 
 #### March 14, 2023
 


### PR DESCRIPTION
Update revision history with PRs that have been merged recently:
- https://github.com/google/transit/pull/379
- https://github.com/google/transit/pull/357

I am marking this PR as a draft until the current votes are finished and will update the revision history with any other PRs that have passed:
- [x] https://github.com/google/transit/pull/378
- [x] https://github.com/google/transit/pull/380
- [x] https://github.com/google/transit/pull/385
- [x] https://github.com/google/transit/pull/386