### PR TITLE
Update README.md website to gtfs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Feed Specification (GTFS) and GTFS Realtime:
 * [GTFS](/gtfs/README.md)
 * [GTFS Realtime](/gtfs-realtime/README.md)
 
-Please visit https://developers.google.com/transit/ for information.
+Please visit https://gtfs.org for information.


### PR DESCRIPTION
Change website from [Google Developers website](https://developers.google.com/transit/) documentation to [gtfs.org](https://gtfs.org/), which contains more up-to-date GTFS documentation.