### PR TITLE
[Stale Bot Fix] Removal of automatic closing of stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 4 * * *'
 
 permissions:
   issues: write
@@ -11,15 +11,11 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9.0.0
         with:
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          close-issue-message: 'This issue has been closed due to inactivity. Issues can always be reopened after they have been closed.'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
           stale-issue-label: 'stale'
           days-before-issue-stale: 365
-          days-before-issue-close: 14
-          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          close-pr-message: 'This pull request has been closed due to inactivity. Pull requests can always be reopened after they have been closed. See the Specification Amendment Process.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
           stale-pr-label: 'stale'
-          days-before-pr-stale: 23
-          days-before-pr-close: 7
+          days-before-pr-stale: 90


### PR DESCRIPTION
After [multiple issues](https://github.com/google/transit/issues/84#issuecomment-1846927596) with automatic closing of Issues and PRs, MobilityData proposes to modify the settings of the stale bot.

- Removal of automatic closing items of stale issues and PRs. 
- Change of stale label for PRs from 23 to 90 days
- Updated to latest version (v.9.0.0)

MobilityData will manually assess each stale label after 1 month of the stale announcement. 