### PR TITLE
[Governance] Phase 1: Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 contact_links:
-  - name: GTFS.org
+  - name: GTFS Documentation
     url: https://gtfs.org/
     about: The official reference for GTFS documentation. 
-  - name: GTFS Changes Google Group
+  - name: GTFS Changes Mailing List
     url: https://groups.google.com/g/gtfs-changes 
     about: Follow this group to get announcement on votes on the GTFS Schedule specification. 
-  - name: GTFS Realtime Google Group 
+  - name: GTFS Realtime Mailing List 
     url: https://groups.google.com/g/gtfs-realtime
     about: This group is the forum for discussing the GTFS Realtime specification, asking questions, and proposing changes.
   - name: GTFS Slack Channel

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+contact_links:
+  - name: GTFS.org
+  - url: https://gtfs.org/
+  - about: The official reference for GTFS documentation. 
+  - name: GTFS Changes Google Group
+  - url: https://groups.google.com/g/gtfs-changes 
+  - about: Follow this group to get announcement on votes on the GTFS Schedule specification. 
+  - name: GTFS Realtime Google Group 
+  - url: https://groups.google.com/g/gtfs-realtime
+  - about: This group is the forum for discussing the GTFS Realtime specification, asking questions, and proposing changes.
+  - name: GTFS Slack Channel
+    url: https://share.mobilitydata.org/slack
+    about: Join the gtfs channel to discuss with other community members, and receive updates.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 contact_links:
   - name: GTFS.org
-  - url: https://gtfs.org/
-  - about: The official reference for GTFS documentation. 
+    url: https://gtfs.org/
+    about: The official reference for GTFS documentation. 
   - name: GTFS Changes Google Group
-  - url: https://groups.google.com/g/gtfs-changes 
-  - about: Follow this group to get announcement on votes on the GTFS Schedule specification. 
+    url: https://groups.google.com/g/gtfs-changes 
+    about: Follow this group to get announcement on votes on the GTFS Schedule specification. 
   - name: GTFS Realtime Google Group 
-  - url: https://groups.google.com/g/gtfs-realtime
-  - about: This group is the forum for discussing the GTFS Realtime specification, asking questions, and proposing changes.
+    url: https://groups.google.com/g/gtfs-realtime
+    about: This group is the forum for discussing the GTFS Realtime specification, asking questions, and proposing changes.
   - name: GTFS Slack Channel
     url: https://share.mobilitydata.org/slack
     about: Join the gtfs channel to discuss with other community members, and receive updates.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,21 @@
+name: Question
+description: Ask a question or raise a problem without a proposed solution.
+labels: ['question']
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting a question, please make sure there isn't an already [existing issue for it](https://github.com/google/transit/issues?q=+is%3Aissue+label%3Aquestion+).
+  - type: textarea
+    attributes:
+      label: Introduce yourself
+      description: >
+        If you are new to the specification, please introduce yourself (name and organization/link to your GTFS feed)!
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Ask a question
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spec_change.yml
+++ b/.github/ISSUE_TEMPLATE/spec_change.yml
@@ -1,0 +1,37 @@
+name: Specification change
+description: Propose a change to the specification.
+labels: ['spec-change']
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting a new change, please make sure the same one isn't already [proposed in an issue](https://github.com/google/transit/issues).
+  - type: textarea
+    attributes:
+      label: Describe the problem
+      description: >
+        Describe what you are trying to achieve.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use cases
+      description: >
+        Share examples of the scenarios you want the proposal to address, e.g GTFS-Fares v2 makes it possible to display the cost of a monthly pass. Show visuals of how it will appear to riders where relevant. [Here's a great example of communicating a complex use case](https://github.com/google/transit/pull/352#issuecomment-1284756181).
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: >
+        A clear description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        Additional information that can help the community better understand your need.
+    validations:
+      required: false


### PR DESCRIPTION
## 📓 Context

As part of Phase 1 of [Epic Issue #413](https://github.com/google/transit/issues/413), MobilityData proposes to add Issue Templates as one of the solutions to help alleviate the high barrier to entry that was rendered evident to us during multiple outreach efforts in 2023. 


## 💡 Proposed Solution 

We propose to implement the following templates and links: 



* Specification Change: Guide the contributor to describe the problem and showcase the proposed solution. 
* Ask a Question: Guide the contributor to provide sufficient information for better answers. 
* Links: Redirect contributors to valuable resources like Slack, GTFS.org, and the Google Groups
* The template page also provides the option to publish a blank issue at the bottom of the page. 


## ℹ️ Additional Information

As the governance changes in the next months, we can expect to change or add templates accordingly. 



* When editorial and "smaller" changes are defined, we can expect to create templates for those cases. 

We welcome the community to review the proposal and provide some feedback. We hope to adopt this change as an editorial change and fast track its adoption if there is a clear consensus in the comments.  