### PR TITLE
Add ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 
 # C extensions
 *.so
+
+# macOS metadata files
+.DS_Store


### PR DESCRIPTION
Ignore .DS_Store, metadata files by macOS that have no utility in the git repo 