### PR TITLE
Add GTFS Feed Version to the GTFS real time FeedHeader

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -83,7 +83,7 @@ message FeedHeader {
   // it can be still provided.
   // The URL should be a fully qualified URL that includes http:// or https://, and any
   // special characters in the URL must be correctly escaped.
-  optional string GTFS_url = 5;
+  optional string gtfs_url = 5;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime specification in order to add and evaluate new features and

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -73,6 +73,18 @@ message FeedHeader {
   // January 1st 1970 00:00:00 UTC).
   optional uint64 timestamp = 3;
 
+  // String that matches the feed_info.feed_version from the GTFS feed that the real
+  // time data is based on. Consumers can use this to identify which GTFS feed is
+  // currently active or when a new one is available to download.
+  optional string feed_version = 4;
+
+  // String containing an URL linking to the GTFS file. It should be the feed that is
+  // currently active. If a link to the upcoming GTFS file is the only one available
+  // it can be still provided.
+  // The URL should be a fully qualified URL that includes http:// or https://, and any
+  // special characters in the URL must be correctly escaped.
+  optional string GTFS_url = 5;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -78,13 +78,6 @@ message FeedHeader {
   // currently active or when a new one is available to download.
   optional string feed_version = 4;
 
-  // String containing an URL linking to the GTFS file. It should be the feed that is
-  // currently active. If a link to the upcoming GTFS file is the only one available
-  // it can be still provided.
-  // The URL should be a fully qualified URL that includes http:// or https://, and any
-  // special characters in the URL must be correctly escaped.
-  optional string gtfs_url = 5;
-
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -97,7 +97,7 @@ Metadata about a feed, included in feed messages.
 | **gtfs_realtime_version** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Version of the feed specification. The current version is 2.0. |
 | **incrementality** | [Incrementality](#enum-incrementality) | Required | One |
 | **timestamp** | [uint64](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | This timestamp identifies the moment when the content of this feed has been created (in server time). In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). To avoid time skew between systems producing and consuming realtime information it is strongly advised to derive timestamp from a time server. It is completely acceptable to use Stratum 3 or even lower strata servers since time differences up to a couple of seconds are tolerable. |
-| **feed_version** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | String that matches the feed_info.feed_version from the GTFS feed that the realtime data is based on. Consumers can use this to identify which GTFS feed is currently active or when a new one is available to download. |
+| **feed_version** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | String that matches the `feed_info.feed_version` from the GTFS feed that the realtime data is based on. Consumers can use this to identify which GTFS feed is currently active or when a new one is available to download. |
 
 ## _enum_ Incrementality
 

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -97,6 +97,7 @@ Metadata about a feed, included in feed messages.
 | **gtfs_realtime_version** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Version of the feed specification. The current version is 2.0. |
 | **incrementality** | [Incrementality](#enum-incrementality) | Required | One |
 | **timestamp** | [uint64](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | This timestamp identifies the moment when the content of this feed has been created (in server time). In POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). To avoid time skew between systems producing and consuming realtime information it is strongly advised to derive timestamp from a time server. It is completely acceptable to use Stratum 3 or even lower strata servers since time differences up to a couple of seconds are tolerable. |
+| **feed_version** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | String that matches the feed_info.feed_version from the GTFS feed that the realtime data is based on. Consumers can use this to identify which GTFS feed is currently active or when a new one is available to download. |
 
 ## _enum_ Incrementality
 


### PR DESCRIPTION
Based on the Issue [Static file version information is missing in the real-time data feed](https://github.com/google/transit/issues/362) opened by @Gerriko, I am proposing adding two new fields to the feed header to provide information on the GTFS file to be used with the GTFS real time data.

The feed_version would match the feed_version in the feed_info.txt file of the GTFS. This indicates which version of the GTFS file is currently being used by the real time data so the consumer knows exactly when to switch to a new file. It can also be used to identify when to check for a new GTFS file.

The GTFS_url would point to the url of the GTFS file. Sometimes agencies have multiple GTFSs and it's not clear which one is to be used. It provides the flexibility to allow the url to point to the upcoming GTFS file, but it is recommended to point to the one being used.

The next step would be for a producer to add support for this feature. This might be well suited for the @MBTA to implement it as they update their GTFS every few days, sometimes with last minute changes.
 