### PR TITLE
Editorial changes: rendering of locations.geojson description + updating booking_rule_id description

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -737,6 +737,7 @@ Assigns stops from stops.txt to location groups.
 File: **Optional**
 
 Defines zones where riders can request either pickup or drop off by on-demand services. These zones are represented as GeoJSON polygons.
+
 - This file uses a subset of the GeoJSON format, described in [RFC 7946](https://tools.ietf.org/html/rfc7946).
 - The `locations.geojson` file must contain a `FeatureCollection`.
 - A `FeatureCollection` defines various stop locations where riders may request pickup or drop off.

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -767,7 +767,7 @@ Defines the booking rules for rider-requested services
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
-| `booking_rule_id` | ID | **Required** | Identifies a rule or set of rules. |
+| `booking_rule_id` | Unique ID | **Required** | Identifies a rule. |
 | `booking_type` | Enum | **Required** | Indicates how far in advance booking can be made. Valid options are:<br><br>`0` - Real time booking.<br>`1` - Up to same-day booking with advance notice.<br>`2` - Up to prior day(s) booking. |
 | `prior_notice_duration_min` | Integer | **Conditionally Required** | Minimum number of minutes before travel to make the request.<br><br>**Conditionally Required**:<br>- **Required** for `booking_type=1`.<br>- **Forbidden** otherwise. |
 | `prior_notice_duration_max` | Integer | **Conditionally Forbidden** | Maximum number of minutes before travel to make the booking request.<br><br>**Conditionally Forbidden**:<br>- **Forbidden** for `booking_type=0` and `booking_type=2`.<br>- Optional for `booking_type=1`.|

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -767,7 +767,7 @@ Defines the booking rules for rider-requested services
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |
-| `booking_rule_id` | ID | **Required** | Identifies the rule. |
+| `booking_rule_id` | ID | **Required** | Identifies a rule or set of rules. |
 | `booking_type` | Enum | **Required** | Indicates how far in advance booking can be made. Valid options are:<br><br>`0` - Real time booking.<br>`1` - Up to same-day booking with advance notice.<br>`2` - Up to prior day(s) booking. |
 | `prior_notice_duration_min` | Integer | **Conditionally Required** | Minimum number of minutes before travel to make the request.<br><br>**Conditionally Required**:<br>- **Required** for `booking_type=1`.<br>- **Forbidden** otherwise. |
 | `prior_notice_duration_max` | Integer | **Conditionally Forbidden** | Maximum number of minutes before travel to make the booking request.<br><br>**Conditionally Forbidden**:<br>- **Forbidden** for `booking_type=0` and `booking_type=2`.<br>- Optional for `booking_type=1`.|


### PR DESCRIPTION
Included in this PR

**1. Rendering of locations.geojson description**
The description of `locations.geojson` doesn't render properly on gtfs.org:
<img width="939" alt="Screenshot 2024-04-10 at 12 41 47 PM" src="https://github.com/google/transit/assets/63653518/099ce539-1321-44c6-979e-459df0ea16e6">

This PR adds a blank line, which should fix the issue (based on some [previous experience](https://github.com/MobilityData/gtfs.org/commit/71601fcac7c4cad8e2302bb0487c2a0c7f4aa53d) I had with this problem). 
This is the result:
<img width="907" alt="Screenshot 2024-04-10 at 12 41 14 PM" src="https://github.com/google/transit/assets/63653518/ef66945e-d188-426a-b6ce-817d9be19962">

**2. Updated booking_rule_id description** 
To be consistent with other descriptions of non-unique IDs (`timeframe_group_id`, `fare_product_id`).