### PR TITLE
[Editorial fix] Fix formatting of bulletpoints in RT spec

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -149,6 +149,7 @@ Depending on the value of ScheduleRelationship, a TripUpdate can specify:
 The updates can be for future, predicted arrival/departure events, or for past events that already occurred. In most cases information about past events is a measured value thus its uncertainty value is recommended to be 0\. Although there could be cases when this does not hold so it is allowed to have uncertainty value different from 0 for past events. If an update's uncertainty is not 0, either the update is an approximate prediction for a trip that has not completed or the measurement is not precise or the update was a prediction for the past that has not been verified after the event occurred.
 
 If a vehicle is serving multiple trips within the same block (for more information about trips and blocks, please refer to [GTFS trips.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt)):
+
 * the feed should include a TripUpdate for the trip currently being served by the vehicle. Producers are encouraged to include TripUpdates for one or more trips after the current trip in this vehicle's block if the producer is confident in the quality of the predictions for these future trip(s). Including multiple TripUpdates for the same vehicle avoids prediction "pop-in" for riders as the vehicle transitions from one trip to another and also gives riders advance notice of delays that impact downstream trips (e.g., when the known delay exceeds planned layover times between trips).
 * the respective TripUpdate entities are not required to be added to the feed in the same order that they are scheduled in the block. For example, if there are trips with `trip_ids` 1, 2, and 3 that all belong to one block, and the vehicle travels trip 1, then trip 2, and then trip 3, the `trip_update` entities may appear in any order - for example, adding trip 2, then trip 1, and then trip 3 is allowed.
 
@@ -437,6 +438,7 @@ A geographic position of a vehicle.
 A descriptor that identifies a single instance of a GTFS trip.
 
 To specify a single trip instance, in many cases a `trip_id` by itself is sufficient. However, the following cases require additional information to resolve to a single trip instance:
+
 * For trips defined in frequencies.txt, `start_date` and `start_time` are required in addition to `trip_id`
 * If the trip lasts for more than 24 hours, or is delayed such that it would collide with a scheduled trip on the following day, then `start_date` is required in addition to `trip_id`
 * If the `trip_id` field can't be provided, then `route_id`, `direction_id`, `start_date`, and `start_time` must all be provided


### PR DESCRIPTION
In gtfs.org, the bullet points don't render properly if there isn't a line before them. We have two instances of this issue on the GTFS RT spec: 
1. In [message TripDecriptor](https://gtfs.org/realtime/reference/#message-tripdescriptor)
<img width="1223" alt="Screenshot 2024-05-21 at 2 18 36 PM" src="https://github.com/google/transit/assets/63653518/36a2f82e-c3cc-44fa-a141-f5f955a873fe">

2. In [message TripUpdate](https://gtfs.org/realtime/reference/#message-tripupdate)
<img width="1228" alt="Screenshot 2024-05-21 at 2 19 12 PM" src="https://github.com/google/transit/assets/63653518/9ae1fb2d-f0c8-43bd-98d5-d1fd2dfb5946">

After this PR, these paragraphs will look like this:

<img width="1094" alt="Screenshot 2024-05-21 at 2 24 12 PM" src="https://github.com/google/transit/assets/63653518/56e04c57-49bb-4667-9d17-07bcdf0d7f4a">
<img width="1093" alt="Screenshot 2024-05-21 at 2 24 41 PM" src="https://github.com/google/transit/assets/63653518/d5925305-e732-4766-bd37-19e4b08b02db">
