### PR TITLE
Update requirement for feed_info.txt

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -138,7 +138,7 @@ This specification defines the following files:
 |  [locations.geojson](#locationsgeojson)  | Optional | Zones for rider pickup or drop-off requests by on-demand services, represented as GeoJSON polygons. |
 |  [booking_rules.txt](#booking_rulestxt)  | Optional | Booking information for rider-requested services. |
 |  [translations.txt](#translationstxt)  | Optional | Translations of customer-facing dataset values. |
-|  [feed_info.txt](#feed_infotxt)  | Optional | Dataset metadata, including publisher, version, and expiration information. |
+|  [feed_info.txt](#feed_infotxt)  | **Conditionally Required** | Dataset metadata, including publisher, version, and expiration information.<br><br>Conditionally Required:<br>- **Required** if [translations.txt](#translationstxt) is provided.<br>- **Recommended** otherwise.|
 |  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
 
 ## File Requirements
@@ -805,7 +805,7 @@ If both referencing methods (`record_id`, `record_sub_id`) and `field_value` are
 
 ### feed_info.txt
 
-File: **Recommended** (**Required** if [translations.txt](#translations) is provided)
+File: **Conditionally Required**
 
 Primary key (none)
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -138,7 +138,7 @@ This specification defines the following files:
 |  [locations.geojson](#locationsgeojson)  | Optional | Zones for rider pickup or drop-off requests by on-demand services, represented as GeoJSON polygons. |
 |  [booking_rules.txt](#booking_rulestxt)  | Optional | Booking information for rider-requested services. |
 |  [translations.txt](#translationstxt)  | Optional | Translations of customer-facing dataset values. |
-|  [feed_info.txt](#feed_infotxt)  | **Conditionally Required** | Dataset metadata, including publisher, version, and expiration information.<br><br>Conditionally Required:<br>- **Required** if [translations.txt](#translationstxt) is provided.<br>- **Recommended** otherwise.|
+|  [feed_info.txt](#feed_infotxt)  | **Conditionally Required** | Dataset metadata, including publisher, version, and expiration information.<br><br>Conditionally Required:<br>- **Required** if [translations.txt](#translationstxt) is provided.<br>- Recommended otherwise.|
 |  [attributions.txt](#attributionstxt)  | Optional | Dataset attributions. |
 
 ## File Requirements


### PR DESCRIPTION
## Problem
When translations.txt was added into GTFS ([source](https://github.com/google/transit/pull/180)), the feed_info.txt file was changed from : 

> File: **Optional**

To:

> File: **Optional** (**Required** if `translations.txt` is provided)

Then, when the Recommended presence was added into GTFS ([source](https://github.com/google/transit/pull/386)), the feed_info.txt file was changed to:

> File: **Recommended** (**Required** if `translations.txt` is provided)

The issue is: the [Dataset Files](https://gtfs.org/schedule/reference/#dataset-files) table at the top of the spec was not updated with these changes; feed_info.txt is still described as **Optional**.

## Solution
In this PR, I modified the dataset file table with what I believe is the right requirement for feed_info.txt: 

> **Conditionally Required**:
> - **Required** if `translations.txt` is provided
> - **Recommended** otherwise