### PR TITLE
Add that shapes should be included

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -582,7 +582,7 @@ File: **Optional**
 
 Primary key (`shape_id`, `shape_pt_sequence`)
 
-Shapes describe the path that a vehicle travels along a route alignment, and are defined in the file shapes.txt. Shapes are associated with Trips, and consist of a sequence of points through which the vehicle passes in order. Shapes do not need to intercept the location of Stops exactly, but all Stops on a trip should lie within a small distance of the shape for that trip, i.e. close to straight line segments connecting the shape points. The shapes.txt file should be included for all services that are route-based (excluding zone-based demand responsive services).
+Shapes describe the path that a vehicle travels along a route alignment, and are defined in the file shapes.txt. Shapes are associated with Trips, and consist of a sequence of points through which the vehicle passes in order. Shapes do not need to intercept the location of Stops exactly, but all Stops on a trip should lie within a small distance of the shape for that trip, i.e. close to straight line segments connecting the shape points. The shapes.txt file should be included for all route-based services (not for zone-based demand-responsive services).
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -582,7 +582,7 @@ File: **Optional**
 
 Primary key (`shape_id`, `shape_pt_sequence`)
 
-Shapes describe the path that a vehicle travels along a route alignment, and are defined in the file shapes.txt. Shapes are associated with Trips, and consist of a sequence of points through which the vehicle passes in order. Shapes do not need to intercept the location of Stops exactly, but all Stops on a trip should lie within a small distance of the shape for that trip, i.e. close to straight line segments connecting the shape points.
+Shapes describe the path that a vehicle travels along a route alignment, and are defined in the file shapes.txt. Shapes are associated with Trips, and consist of a sequence of points through which the vehicle passes in order. Shapes do not need to intercept the location of Stops exactly, but all Stops on a trip should lie within a small distance of the shape for that trip, i.e. close to straight line segments connecting the shape points. The shapes.txt file should be included for all services that are route-based (excluding zone-based demand responsive services).
 
 |  Field Name | Type | Presence | Description |
 |  ------ | ------ | ------ | ------ |


### PR DESCRIPTION
## Context
This PR follow-up on issue https://github.com/google/transit/issues/45, which received good engagement. 
This originated form an issue by @e-lo for the [GTFS Schedule Best Practices](https://gtfs.org/schedule/best-practices/). 
We'd like to eventually have the Best Practices and the specifications consolidated into one document, so we are incorporating new Best Practices directly into the spec (see efforts to merge the specifications and Best Practices [here](https://github.com/google/transit/issues/396) and [here](https://github.com/google/transit/issues/451)). 

## Proposal
This PR adds the following mention in [shapes.txt](https://gtfs.org/schedule/reference/#shapestxt) description: 

> The shapes.txt file should be included for all route-based services (not for zone-based demand-responsive services).

Given that zone-based services can now be modeled in GTFS and don't need `shapes.txt` defined, I didn't modify the [Presence type](https://gtfs.org/schedule/reference/#presence) of shapes.txt to _Recommended_, and rather chose a "should" statement in its description. 

Note that merging this PR means we'd add a WARNING in the [Canonical GTFS Schedule Validator](https://gtfs-validator.mobilitydata.org/), which is the severity level for all GTFS Best Practices (spec _should_ & _recommended_ + everything in the Best Practices). 