### PR TITLE
Change stops.txt presence because of demand responsive services 

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -111,7 +111,7 @@ This specification defines the following files:
 |  File Name | Presence | Description |
 |  ------ | ------ | ------ |
 |  [agency.txt](#agencytxt) | **Required** | Transit agencies with service represented in this dataset. |
-|  [stops.txt](#stopstxt) | **Required** | Stops where vehicles pick up or drop off riders. Also defines stations and station entrances.  |
+|  [stops.txt](#stopstxt) | **Conditionally Required** | Stops where vehicles pick up or drop off riders. Also defines stations and station entrances. <br><br>Conditionally Required:<br> - **Required** if [locations.geojson](#locationsgeojson) does not exist. <br>- Optional otherwise. |
 |  [routes.txt](#routestxt) | **Required** | Transit routes. A route is a group of trips that are displayed to riders as a single service. |
 |  [trips.txt](#tripstxt)  | **Required** | Trips for each route. A trip is a sequence of two or more stops that occur during a specific time period. |
 |  [stop_times.txt](#stop_timestxt) | **Required** | Times that a vehicle arrives at and departs from stops for each trip. |
@@ -194,7 +194,7 @@ Primary key (`agency_id`)
 
 ### stops.txt
 
-File: **Required**
+File: **Conditionally Required**
 
 Primary key (`stop_id`)
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -111,7 +111,7 @@ This specification defines the following files:
 |  File Name | Presence | Description |
 |  ------ | ------ | ------ |
 |  [agency.txt](#agencytxt) | **Required** | Transit agencies with service represented in this dataset. |
-|  [stops.txt](#stopstxt) | **Conditionally Required** | Stops where vehicles pick up or drop off riders. Also defines stations and station entrances. <br><br>Conditionally Required:<br> - **Required** if [locations.geojson](#locationsgeojson) does not exist. <br>- Optional otherwise. |
+|  [stops.txt](#stopstxt) | **Conditionally Required** | Stops where vehicles pick up or drop off riders. Also defines stations and station entrances. <br><br>Conditionally Required:<br> - Optional if demand-responsive zones are defined in [locations.geojson](#locationsgeojson). <br>- **Required** otherwise. |
 |  [routes.txt](#routestxt) | **Required** | Transit routes. A route is a group of trips that are displayed to riders as a single service. |
 |  [trips.txt](#tripstxt)  | **Required** | Trips for each route. A trip is a sequence of two or more stops that occur during a specific time period. |
 |  [stop_times.txt](#stop_timestxt) | **Required** | Times that a vehicle arrives at and departs from stops for each trip. |


### PR DESCRIPTION
### Context

Before the adoption of GTFS-Flex in [PR#433](https://github.com/google/transit/pull/433), `stops.txt`was the sole file in GTFS defining the geographic locations (geometry: points) where riders board and alight. However, after its adoption, producers can define riders boarding and alighting geographic areas through `locations.geojson` (geometry: polygons) as well. In theory, an agency may exclusively offer zone-based demand-responsive services, in which case the feed may only contain `locations.geojson` without `stops.txt`.

### Proposed change in this PR
Therefore, suggest changing the presence of `stops.txt` from `Required` to `Conditionally required` (required if `locations.geojson` doesn't exist, optional otherwise). 

### GTFS validator behavior

Once the spec is modified, the GTFS validator can make corresponding adjustments, such as:
- Both `stops.txt` and `locations.geojson` exist - no error
- Either `stops.txt` or `locations.geojson` exists - no error
- Neither `stops.txt` nor `locations.geojson` exists - error (missing required file stops.txt)

**Conditionally required vs Optional**
If both `stops.txt` and `locations.geojson` are optional, the GTFS validator won't show an error when neither `stops.txt` nor `locations.geojson` exists. If there is no geographic information defining where riders boarding and alighting in the feed, the feed seems invalid to me. 

Since `stops.txt` is one of the fundamental file in GTFS, we plan to open a vote on this change.
cc: @westontrillium @leonardehrenfried @tsherlockcraig @gcamp 