### PR TITLE
Fixing Stalebot 2.0

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,12 @@ jobs:
     steps:
       - uses: actions/stale@v9.0.0
         with:
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
-          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been automatically marked as stale because of lack of recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
+          stale-issue-label: 'Status: Stale'
           days-before-issue-stale: 365
-          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
-          stale-pr-label: 'stale'
+          days-before-issue-close: -1
+
+          stale-pr-message: 'This pull request has been automatically marked as stale because of lack of recent activity. It may be closed manually after one month of inactivity. Thank you for your contributions.'
+          stale-pr-label: 'Status: Stale'
           days-before-pr-stale: 90
+          days-before-pr-close: -1


### PR DESCRIPTION
The stalebot was still closing issues and PRs automatically again. We hope this fix will remove automatic closure. We also updated the stale label to fit with our current label formatting type.