### PR TITLE
Add validity rules for polygons in locations.geojson

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -747,6 +747,7 @@ File: **Optional**
 Defines zones where riders can request either pickup or drop off by on-demand services. These zones are represented as GeoJSON polygons.
 
 - This file uses a subset of the GeoJSON format, described in [RFC 7946](https://tools.ietf.org/html/rfc7946).
+- Each polygon must be valid by the definition of the [OpenGis Simple Features Specification, section 6.1.11](https://portal.ogc.org/files/?artifact_id=25355).
 - The `locations.geojson` file must contain a `FeatureCollection`.
 - A `FeatureCollection` defines various stop locations where riders may request pickup or drop off.
 - Every GeoJSON `Feature` must have an `id`. The `id` must be unique across all `stops.stop_id`, locations.geojson `id`, and `location_group_id` values.

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -747,7 +747,7 @@ File: **Optional**
 Defines zones where riders can request either pickup or drop off by on-demand services. These zones are represented as GeoJSON polygons.
 
 - This file uses a subset of the GeoJSON format, described in [RFC 7946](https://tools.ietf.org/html/rfc7946).
-- Each polygon must be valid by the definition of the [OpenGis Simple Features Specification, section 6.1.11](https://portal.ogc.org/files/?artifact_id=25355).
+- Each polygon must be valid by the definition of the [OpenGIS Simple Features Specification, section 6.1.11](http://www.opengis.net/doc/is/sfa/1.2.1).
 - The `locations.geojson` file must contain a `FeatureCollection`.
 - A `FeatureCollection` defines various stop locations where riders may request pickup or drop off.
 - Every GeoJSON `Feature` must have an `id`. The `id` must be unique across all `stops.stop_id`, locations.geojson `id`, and `location_group_id` values.


### PR DESCRIPTION
### Problem

When you have self-intersecting polygons in locations.geojson, there can be situations where routing engines cannot decide if a point is inside or outside of it:

![image](https://github.com/google/transit/assets/151346/95ad3ce5-b1cd-479b-8abd-d6fec328f56a)

Yesterday I asked in Slack about validity rules of flex polygons and received positive responses about tightening them.

For this reason, I'm opening this PR to gather more feedback and eventually call a vote.

Rather than spelling out all the ways in which polygons can be invalid or just mentioning self-intersecting ones, I opted instead to reference another standard that has been battle hardened and has a very good description of of validity rules for polygons.

![image](https://github.com/google/transit/assets/151346/0a38c9ac-90f8-4828-b099-bb647c278df7)

cc @miles-grant-ibigroup @m-mcqueen @LeoFrachet