### PR TITLE
Clarification of CANCELED/SKIPPED TripUpdates VS NO_SERVICE Alerts

### DIFF
--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -1,4 +1,6 @@
-Service alerts allow you to provide updates whenever there is disruption on the network. Delays and cancellations of individual trips should usually be communicated using [Trip updates](trip-updates.md).
+Service alerts allow you to provide updates whenever there is disruption on the network. Delays and cancellations of individual trips should usually be communicated using [Trip updates](trip-updates.md). 
+Alerts should be used for notifying that a stop will be out of service for extended periods.
+Alerts can be used by consumers to modify trip planner behavior. 
 
 You have the option to provide the following:
 
@@ -22,7 +24,7 @@ Entities are selected using their GTFS identifiers, and you can select any of th
 *   Route - affects the whole route
 *   Route type - affects any route of this type. e.g. all subways.
 *   Trip - affects a particular trip
-*   Stop - affects a particular stop
+*   Stop - affects a particular stop.
 
 You may include more than one of the fields listed above in one `informed_entity`. When multiple fields are included in one `informed_entity`, they should be interpreted as being joined by the `AND` logical operator. In other words, the alert should only be applied in a context that meets all of the fields provided in an `informed_entity`. For example, if `route_id: "1"` and `stop_id: "5"` are both included in one `informed_entity`, then the alert should apply only to route 1 at stop 5.  It should NOT be applied to any other stop on route 1, and it should NOT be applied to any other route at stop 5.
 
@@ -49,7 +51,7 @@ What is the cause of this alert? You may specify one of the following:
 
 What effect does this problem have on the specified entity? You may specify one of the following:
 
-*   No service
+*   No service: If an Alert with Effect No service exists and conflicts with values in [Trip updates](trip-updates.md), Alerts should be considered the source of truth. 
 *   Reduced service
 *   Significant delays (insignificant delays should only be provided through [Trip updates](trip-updates.md)).
 *   Detour


### PR DESCRIPTION
This PR is intended to close #469 with a solution different than the one initially proposed in the issue, based on the feedback received.
The rationale, more context and reference materials for this PR are available in this document: https://share.mobilitydata.org/alerts-proposal.

## Issues 
1. In GTFS Realtime, both Alerts and TripUpdates can theoretically be used when trips/routes/route_types/stops are not in service. Although this seems very unlikely one would use TripUpdates for routes, both could be used for trips and stops. 
2. Alerts could imply that they are only used to communicate rider-facing messages, but Alerts are also the most efficient way to communicate that an entity is closed for extended periods, ensuring trip planners can adjust algorithms accordingly.

## What the spec currently says
- In Feed entities ([source](https://gtfs.org/realtime/feed-entities/service-alerts/#service-alerts)):

> Delays and cancellations of individual trips should usually be communicated using [Trip updates](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/trip-updates.md).


- In the GTFS Best Practices ([source](https://gtfs.org/realtime/best-practices/#alert)):

> When canceling trips over several days, producers should provide TripUpdates referencing the given trip_ids and start_dates as CANCELED as well as an Alert with NO_SERVICE referencing the same trip_ids and TimeRange that can be shown to riders explaining the cancellation (e.g., detour).

## Proposed solution
Given that Alerts are easier to produce and are generally more efficient and informative in describing cancelations, we propose that:
- If an Alert with Effect.NO_SERVICE exists and conflicts with values in TripUpdates, **Alerts should be considered the source of truth.** 
- Alerts should be used for notifying that a stop will be out of service **for extended periods**.
- Alerts **can be used** by consumers to modify trip planner behavior. 

This PR adds these three statements to the GTFS Realtime spec.

Does this seem like a reasonable solution?
Do we need to add more details to what "extended periods" means?

Tagging folks who provided feedback to the issue @optionsome @dbabramov @gcamp @leonardehrenfried @IvanVolosyuk. 