### PR TITLE
fix whitespace in .proto file

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -220,7 +220,7 @@ message TripUpdate {
     // In order to provide departure_occupancy_status without either arrival or
     // departure StopTimeEvents, ScheduleRelationship should be set to NO_DATA. 
     optional VehiclePosition.OccupancyStatus departure_occupancy_status = 7;
-    
+
     // The relation between the StopTimeEvents and the static schedule.
     enum ScheduleRelationship {
       // The vehicle is proceeding in accordance with its static schedule of
@@ -252,7 +252,7 @@ message TripUpdate {
       UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
-        [default = SCHEDULED];
+    [default = SCHEDULED];
 
     // Provides the updated values for the stop time.
     // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
@@ -641,10 +641,10 @@ message Alert {
 
   // Severity of this alert.
   enum SeverityLevel {
-	UNKNOWN_SEVERITY = 1;
-	INFO = 2;
-	WARNING = 3;
-	SEVERE = 4;
+    UNKNOWN_SEVERITY = 1;
+    INFO = 2;
+    WARNING = 3;
+    SEVERE = 4;
   }
 
   optional SeverityLevel severity_level = 14 [default = UNKNOWN_SEVERITY];
@@ -652,18 +652,18 @@ message Alert {
   // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
   // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. 
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
-  optional TranslatedImage image = 15; 
+  optional TranslatedImage image = 15;
 
   // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
   // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString image_alternative_text = 16;
-  
-  
+
+
   // Description of the cause of the alert that allows for agency-specific language; more specific than the Cause. If cause_detail is included, then Cause must also be included.
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString cause_detail = 17;
-  
+
   // Description of the effect of the alert that allows for agency-specific language; more specific than the Effect. If effect_detail is included, then Effect must also be included.
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString effect_detail = 18;
@@ -810,7 +810,7 @@ message TripDescriptor {
     CANCELED = 3;
 
     // Should not be used - for backwards-compatibility only.
-    REPLACEMENT = 5 [deprecated=true];
+    REPLACEMENT = 5 [deprecated = true];
 
     // An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to
     // respond to sudden passenger load. Used with TripUpdate.TripProperties.trip_id, TripUpdate.TripProperties.start_date,
@@ -1028,7 +1028,7 @@ message Shape {
   // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
   // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional string shape_id = 1;
-  
+
   // Encoded polyline representation of the shape. This polyline must contain at least two points.
   // For more information about encoded polylines, see https://developers.google.com/maps/documentation/utilities/polylinealgorithm
   // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"
@@ -1052,7 +1052,7 @@ message Stop {
     UNKNOWN = 0;
     AVAILABLE = 1;
     NOT_AVAILABLE = 2;
-   }
+  }
 
   optional string stop_id = 1;
   optional TranslatedString stop_code = 2;
@@ -1130,9 +1130,9 @@ message TripModifications {
 
     // The following extension IDs are reserved for private use by any organization.
     extensions 9000 to 9999;
-}
+  }
 
-   // A list of selected trips affected by this TripModifications.
+  // A list of selected trips affected by this TripModifications.
   repeated SelectedTrips selected_trips = 1;
 
   // A list of start times in the real-time trip descriptor for the trip_id defined in trip_ids. 
@@ -1144,7 +1144,7 @@ message TripModifications {
   repeated string service_dates = 3;
 
   // A list of modifications to apply to the affected trips. 
-  repeated Modification modifications = 4; 
+  repeated Modification modifications = 4;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
@@ -1157,7 +1157,7 @@ message TripModifications {
 
 // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
 // Select a stop by stop sequence or by stop_id. At least one of the two values must be provided.
-message StopSelector { 
+message StopSelector {
   // Must be the same as in stop_times.txt in the corresponding GTFS feed.
   optional uint32 stop_sequence = 1;
   // Must be the same as in stops.txt in the corresponding GTFS feed.


### PR DESCRIPTION
There was a couple of places the `}` indentation was obviously wrong on the site, I first noticed it on `SelectedTrips` (see screenshot). I found this to be confusing.

When I applied the protobuf formatter to the file it also fixed some misc. issues like tabs, spaces around ` = ` for the `deprecated` annotation, and trailing whitespace. I'm not as opinionated about these things, but I did find [precedent](https://github.com/google/transit/pull/142) for cleaning them up.


![Screenshot 2024-08-08 at 10 48 49](https://github.com/user-attachments/assets/8c34f17e-fcd1-4ecd-8390-f1c13f84f504)
