### PR TITLE
Adjust trip modifications

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -848,6 +848,20 @@ message TripDescriptor {
 
     // The trip_id from the GTFS feed that is modified by the modifications_id
     optional string affected_trip_id = 2;
+
+    // The initially scheduled start time of this trip instance, applied to the frequency based modified trip. Same definition as start_time in TripDescriptor.
+    optional string start_time = 3;
+
+    // The start date of this trip instance in YYYYMMDD format, applied to the modified trip. Same definition as start_date in TripDescriptor.
+    optional string start_date = 4;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
   optional ModifiedTripSelector modified_trip = 7;
 
@@ -1180,6 +1194,10 @@ message ReplacementStop {
 
   // The replacement stop ID which will now be visited by the trip. May refer to a new stop added using a GTFS-RT Stop message, or to an existing stop defined in the GTFS-Static feed’s stops.txt. The stop MUST have location_type=0 (routable stops).
   optional string stop_id = 2;
+
+  // The amount of time difference between the scheduled arrival time and departure time. If not specified, the same dwell time from the schedule is applied.
+  // If specified, the arrival time of the replacement stop is defined as `reference_stop.departure_time + travel_time_to_stop` and departure time is defined as `reference_stop.departure_time + travel_time_to_stop + dwell_time`
+  optional uint32 dwell_time = 3;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and

--- a/gtfs-realtime/spec/en/trip-modifications.md
+++ b/gtfs-realtime/spec/en/trip-modifications.md
@@ -23,7 +23,7 @@ The scheduled stop times of each replacement trip are created from those of the 
 
 * A TripUpdate SHOULD be provided using a `ModifiedTripSelector` inside the TripUpdate's `TripDescriptor`. 
     * When the TripUpdate refers to the replacement trip, the consumer should behave as if the static GTFS would have been modified with the TripModifications (e.g. `arrival_time`, `departure_time`, `stop_sequence`, `stop_id` on replacement stops).
-    * When providing a `ModifiedTripSelector`, the other fields of the `TripDescriptor` MUST be left empty, to avoid confusion by consumers that aren't looking for the `ModifiedTripSelector` value. 
+    * When providing a `ModifiedTripSelector`, the `trip_id`, `route_id`, `direction_id`, `start_time`, `start_date` fields of the `TripDescriptor` MUST be left empty, to avoid confusion by consumers that aren't looking for the `ModifiedTripSelector` value. 
     * TripUpdate feeds providing updates with `ModifiedTripSelector` SHOULD also include a TripUpdate targeting clients that don't support TripModifications. In other words, there should be two TripUpdates: one for clients with modified trips (with `TripModifications`) and one for clients with the originial unmodified GTFS (without `TripModifications`).
     * Providing a TripUpdate with a `ModifiedTripSelector` is the only way to create predictions at replacement stops.
 * If no such TripUpdate is found, TripUpdates for the original `trip_id` will apply to the modified trip. 
@@ -34,7 +34,9 @@ The scheduled stop times of each replacement trip are created from those of the 
 
 A `Modification` message describes changes to each affected trip starting at `start_stop_selector`. There can be zero, one, or more than one stop time(s) replaced by a `Modification`. The spans of the modifications MUST not overlap. Spans may not be contiguous; in this case the two modifications MUST be merged into one.  These stop times are replaced with a new stop time for each replacement stop described by `replacement_stops`.
 
-The sequence of `replacement_stops` may be of arbitrary length. For example, 3 stops could be replaced by 2, 4, or 0 stops as the situation may require.
+The sequence of `replacement_stops` may be of arbitrary length. For example, 3 stops could be replaced by 2, 4, or 0 stops as the situation may require. 
+
+It's allowed to replace a stop with a `ReplacementStop` that is the same as in the schedule if some other value are changing (like `dwell_time` `travel_time_to_stop`). 
 
 ![](images/trip_modification.png)
 
@@ -50,7 +52,7 @@ Each `ReplacementStop` message defines a stop that will now be visited by the tr
 
 When `travel_time_to_stop` is specified, the `arrival_time` is calculated from a reference stop in the original trip, plus the offset in `travel_time_to_stop`. Otherwise, the `arrival_time` can be be interpolated based on the total duration of the modification in the original trip.
 
-The `departure_time` always equals the `arrival_time`.
+The dwell time can be defined with the `dwell_time` field, and by default it's 0.
 
 The optional fields of [`stop_times.txt`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt) in the (CSV) GTFS specification are all set to their default values.
 


### PR DESCRIPTION
- Addition of `start_time` and `start_date` to `ModifiedTripSelector` for frequency service support
- Adding missing extensions fields for ModifiedTripSelector
- Explicitly allow use of `schedule_relationship` in `TripDescriptor` when using a `ModifiedTripSelector`.
- Addition of `dwell_time` to define time stopped at temporary stop. At the same time, explicitly support replacing existing stop by the same stop in `ReplacementStop` if some value are changing.
- Add missing documentation in reference.md (it was only specified in the .proto)