### PR TITLE
Update revision history (October 2024)

### DIFF
--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -1,43 +1,47 @@
 ### Revision History
 
+#### October 2024
+
+* Clarification and small changes for Trip Modifications. See [discussion](https://github.com/google/transit/pull/497).
+
 #### March 2024
 
 * Adopted Trip-Modifications. See [discussion](https://github.com/google/transit/pull/403).
 
-### November 2022
+#### November 2022
 
 * Added support for DELETED trips. See [discussion](https://github.com/google/transit/pull/352).
 
-### July 2022
+#### July 2022
 
 * Add cause_detail and effect_detail. See [discussion](https://github.com/google/transit/pull/332)
 * Added ability to specify a wheelchair_accessible value in a TripUpdate.VehicleDescriptor. See [discussion](https://github.com/google/transit/pull/340).
 
-### September 2021
+#### September 2021
 
 * Feature/image in alerts. See [discussion](https://github.com/google/transit/pull/283).
 
-### August 2021
+#### August 2021
 
 * Add GTFS-NewShapes as experimental. See [discussion](https://github.com/google/transit/pull/272).
 
-### April 2021
+#### April 2021
 
 * Add departure_occupancy_status to TripUpdate. See [discussion](https://github.com/google/transit/pull/260).
 
-### February 2021
+#### February 2021
 
 * Clarification of GTFS Realtime occupancy descriptions. See [discussion](https://github.com/google/transit/pull/259).
 
-### September 2020 
+#### September 2020 
 
 * Support multi-car crowding. See [discussion](https://github.com/google/transit/pull/237).
 
-### April 2020
+#### April 2020
 
 * Support stop assignments. See [discussion](https://github.com/google/transit/pull/219).
 
-### July 2020
+#### July 2020
 
 * Support DUPLICATED trips. See [discussion](https://github.com/google/transit/pull/221).
 * Alert tts_header_text, tts_description_text no longer experimental. See [discussion](https://github.com/google/transit/pull/229).

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Aug 16, 2024. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised Oct 16, 2024. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,15 +1,15 @@
 ### Revision History
 
-### September 2024
+#### September 2024
 * Clarify presence and use of from/to_stop_id & from/to_trip_id fields in transfers.txt. See [discussion](https://github.com/google/transit/pull/455).
 * Added validity rules for polygons in GeoJSON files. See [discussion](https://github.com/google/transit/pull/476).
 
-### August 2024
+#### August 2024
 * Change stops.txt presence because of demand responsive services. See [discussion](https://github.com/google/transit/pull/472).
 * Clarify intended use for timepoint in stop_times.txt. See [discussion](https://github.com/google/transit/pull/474).
 * Add that headsigns are recommended. See [discussion](https://github.com/google/transit/pull/485).
 
-### July 2024
+#### July 2024
 * Update requirement for feed_info.txt. See [discussion](https://github.com/google/transit/pull/460).
 * Add that shapes should be included. See [discussion](https://github.com/google/transit/pull/470).
 


### PR DESCRIPTION
Update revision history with the changes merged in October 2024:

- #497 

Editorial changes merged in October but not included in the revision history:
- #489 
- #510 

This PR also includes some minor formatting adjustments for the Schedule and Realtime revision histories and updates the latest revision date in the Schedule reference document.
