### PR TITLE
Clarify use of agency_fare_url

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -193,7 +193,7 @@ Primary key (`agency_id`)
 |  `agency_timezone` | Timezone | **Required** | Timezone where the transit agency is located. If multiple agencies are specified in the dataset, each must have the same `agency_timezone`. |
 |  `agency_lang` | Language code | Optional | Primary language used by this transit agency. Should be provided to help GTFS consumers choose capitalization rules and other language-specific settings for the dataset. |
 |  `agency_phone` | Phone number | Optional | A voice telephone number for the specified agency. This field is a string value that presents the telephone number as typical for the agency's service area. It may contain punctuation marks to group the digits of the number. Dialable text (for example, TriMet's "503-238-RIDE") is permitted, but the field must not contain any other descriptive text. |
-|  `agency_fare_url` | URL | Optional | URL of a web page that allows a rider to purchase tickets or other fare instruments for that agency online. |
+|  `agency_fare_url` | URL | Optional | URL of a web page where a rider can purchase tickets or other fare instruments for that agency, or a web page containing information about that agency's fares. |
 |  `agency_email` | Email | Optional | Email address actively monitored by the agency’s customer service department. This email address should be a direct contact point where transit riders can reach a customer service representative at the agency. |
 
 ### stops.txt


### PR DESCRIPTION
Right now, the definition of `agency_fare_url` is "URL of a web page that allows a rider to purchase tickets or other fare instruments for that agency online."

However, in practice it seems that very few if any url used in `agency_fare_url` allow purchase of tickets but instead just has information on the fares themselves with no way to purchase directly.

This proposal update the agency_fare_url description to be more wide and include fare information only. 

Originally discussed in https://github.com/google/transit/issues/523
