### PR TITLE
Update revision history (Nov-Dec 2024)

### DIFF
--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -1,5 +1,9 @@
 ### Revision History
 
+#### December 2024
+
+* Added new string field that matches feed_info.feed_version from the GTFS Schedule feed that the realtime data is based on. See [discussion](https://github.com/google/transit/pull/434).
+
 #### October 2024
 
 * Clarification and small changes for Trip Modifications. See [discussion](https://github.com/google/transit/pull/497).

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Oct 16, 2024. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised Dec 5, 2024. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,8 @@
 ### Revision History
 
+#### December 2024
+* Added `fare_leg_join_rules.txt` and introduced the concept of Effective Fare Leg. See [discussion](https://github.com/google/transit/pull/439).
+
 #### September 2024
 * Clarify presence and use of from/to_stop_id & from/to_trip_id fields in transfers.txt. See [discussion](https://github.com/google/transit/pull/455).
 * Added validity rules for polygons in GeoJSON files. See [discussion](https://github.com/google/transit/pull/476).


### PR DESCRIPTION
Update revision history with the changes merged between November and until December 16th 2024:

- https://github.com/google/transit/pull/434
- https://github.com/google/transit/pull/439

This PR also updates the latest revision date in the Schedule reference document.