### PR TITLE
Addition of event_based_trips.txt to specification

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -32,6 +32,7 @@ This document defines the format and structure of the files that comprise a GTFS
     -   [route_networks.txt](#route_networkstxt)
     -   [shapes.txt](#shapestxt)
     -   [frequencies.txt](#frequenciestxt)
+    -   [event_based_trips.txt](#event_based_tripstxt)
     -   [transfers.txt](#transferstxt)
     -   [pathways.txt](#pathwaystxt)
     -   [levels.txt](#levelstxt)
@@ -633,6 +634,24 @@ Primary key (`trip_id`, `start_time`)
 |  `end_time` | Time | **Required** | Time at which service changes to a different headway (or ceases) at the first stop in the trip. |
 |  `headway_secs` | Positive integer | **Required** | Time, in seconds, between departures from the same stop (headway) for the trip, during the time interval specified by `start_time` and `end_time`. Multiple headways may be defined for the same trip, but must not overlap. New headways may start at the exact time the previous headway ends.  |
 |  `exact_times` | Enum | Optional | Indicates the type of service for a trip. See the file description for more information. Valid options are:<br><br>`0` or empty - Frequency-based trips.<br>`1` - Schedule-based trips with the exact same headway throughout the day. In this case the `end_time` value must be greater than the last desired trip `start_time` but less than the last desired trip start_time + `headway_secs`. |
+
+
+### event_based_trips.txt
+
+File: **Optional**
+
+Primary Key: `trip_id`
+
+[Event_based_trips.txt](#event_based_tripstxt) identifies trips whose times are coupled to an event's happening (e.g. the conclusion of a concert or sporting event), and are thus variable in nature.
+
+| Field Name | Type | Presence | Description |
+|  ------ | ------ | ------ | ------ |
+| `trip_id` | Foreign ID referencing `trips.trip_id` | **Required** | Identifies a trip to be governed by an event's end time. |
+| `event_end_approximate` | Time | **Required** | Expected time at which the event will end, upon which the special event trips would be based. |
+| `event_end_earliest` | Time | Optional | Earliest event end time for which this trip could run. |
+| `event_end_latest` | Time | Optional | Latest event end time for which this trip could run. |
+| `event_fares` | Enum | Optional | Specifies the fare policy in place for the specified trip.<br>`0` or empty - uses default fare rules<br>`1` - uses special fare policy |
+
 
 ### transfers.txt
 


### PR DESCRIPTION
Draft PR to address #526

## Example

Transit Agency X is running a special event train service to a football game starting at 7:00 PM with an estimated end time of 10:00 PM. There are two trains scheduled to leave the football stadium, both 30 minutes and 60 minutes after the game ends.

If the event ends early, the agency can accommodate passengers immediately, meaning that the first train can leave as early as 7:30 PM.

Due to federal rest restrictions, the final train must leave by midnight, and the prior train must leave by 11:45 PM. The latest the game can end while supporting the scheduled service pattern would be 11:00 PM for the second train, and 11:15 PM for the first train.

The first scheduled departure trip has trip_id `trip_approx_1` and the second trip has ID `trip_approx_2`. Only passengers with a special event ticket are able to ride.

**stop_times.txt**

```csv
trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type,timepoint
trip_approx_1,22:30:00,22:30:00,stadium,10,0,1,0
trip_approx_1,23:00:00,23:00:00,suburb,20,1,0,0
trip_approx_1,23:15:00,23:15:00,downtown,30,1,0,0
trip_approx_2,23:00:00,23:00:00,stadium,10,0,1,0
trip_approx_2,23:30:00,23:30:00,suburb,20,1,0,0
trip_approx_2,23:45:00,23:45:00,downtown,30,1,0,0
```

**event_based_trips.txt**

```csv
trip_id,event_end_approximate,event_end_earliest,event_end_latest,event_fares
trip_approx_1,22:00:00,19:00:00,23:00:00,1
trip_approx_2,22:00:00,19:00:00,23:00:00,1
```


## Notes

- `stop_times.txt` shows the **approximate** stop times for each trip, assuming that the event ends at its expected time.
	- By using `stop_times.txt` and the `event_end_earliest` and `event_end_latest` fields, one can determine the earliest and latest stop times for each trip.
	- Using the `event_end_apprximate` field, one can determine how long after the event each trip departs.
- The `event_end_latest` field may not be the same between trips. For example, NJ Transit's River Line must do a short trip during late-night service due to track restrictions. Thus, a hypothetical event must have an earlier end time to support trips that cover the entire line.