### PR TITLE
Update revision history (January 2025)

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Dec 5, 2024. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised Jan 23, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,8 @@
 ### Revision History
 
+#### January 2025
+* Update agency_fare_url to expand its description and include fare information only. See [discussion](https://github.com/google/transit/pull/524).
+
 #### December 2024
 * Added `fare_leg_join_rules.txt` and introduced the concept of Effective Fare Leg. See [discussion](https://github.com/google/transit/pull/439).
 


### PR DESCRIPTION
Update revision history with the changes merged in January 2025:

- https://github.com/google/transit/pull/524

This PR also updates the latest revision date in the Schedule reference document.