### PR TITLE
Update revision history (February 2025)

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Jan 23, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised Feb 24, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,8 @@
 ### Revision History
 
+#### February 2025
+* Added rider_categories.txt. See [discussion](https://github.com/google/transit/pull/511).
+
 #### January 2025
 * Update agency_fare_url to expand its description and include fare information only. See [discussion](https://github.com/google/transit/pull/524).
 


### PR DESCRIPTION
Update revision history with the changes merged in February 2025:

- [[GTFS Fares v2] Add rider_categories.txt #511](https://github.com/google/transit/pull/511)

Editorial changes merged in February but not included in the revision history:

- [[Editorial] Update "files associated with GTFS-Fares V2" #539](https://github.com/google/transit/pull/539)

This PR also updates the latest revision date in the Schedule reference document.