### PR TITLE
Add cars_allowed field to trips.txt

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -263,6 +263,7 @@ Primary key (`trip_id`)
 |  `shape_id` | Foreign ID referencing `shapes.shape_id` | **Conditionally Required** | Identifies a geospatial shape describing the vehicle travel path for a trip. <br><br>Conditionally Required: <br>- **Required** if the trip has a continuous pickup or drop-off behavior defined either in [routes.txt](#routestxt) or in [stop_times.txt](#stop_timestxt). <br>- Optional otherwise. |
 |  `wheelchair_accessible` | Enum | Optional | Indicates wheelchair accessibility. Valid options are:<br><br>`0` or empty - No accessibility information for the trip.<br>`1` - Vehicle being used on this particular trip can accommodate at least one rider in a wheelchair.<br>`2` - No riders in wheelchairs can be accommodated on this trip. |
 |  `bikes_allowed` | Enum | Optional | Indicates whether bikes are allowed. Valid options are:<br><br>`0` or empty - No bike information for the trip.<br>`1` - Vehicle being used on this particular trip can accommodate at least one bicycle.<br>`2` - No bicycles are allowed on this trip. |
+|  `cars_allowed` | Enum | Optional | Indicates whether cars are allowed. Valid options are:<br><br>`0` or empty - No car information for the trip.<br>`1` - Vehicle being used on this particular trip can accommodate at least one car.<br>`2` - No cars are allowed on this trip. |
 
 #### Example: Blocks and service day
 


### PR DESCRIPTION
## Summary

This PR proposes adding a `cars_allowed` field to `trips.txt`. There was a lot of discussion in issue https://github.com/google/transit/issues/466 about how to add car information for ferries to GTFS. The discussion was centered around whether to use an approach with `stop_times.txt` or `trips.txt`. A recent PR https://github.com/google/transit/pull/533 related to the topic generated discussion about `bikes_allowed`.

Because Digitransit will soon use the `cars_allowed` field in production through OTP and because of the discussion in https://github.com/google/transit/pull/533, I thought that it would be a good idea to create this proposal. It would be interesting to see if there is interest in this.

## Proposal

### Describe the problem

Ferries can have the possibility to have cars on board. For these ferries a field indicating whether cars are allowed would be useful.
In addition to car ferries, this can also apply to, for example, trains that can transport cars in a similar way.

### Use cases

For example:
* To be able to distinguish car ferries.
* To be able to distinguish trains with car transportation capabilities.

### Proposed solution

The trips.txt GTFS file (https://gtfs.org/schedule/reference/#tripstxt) contains the field `bikes_allowed`
which specifies whether bikes are allowed on board. For car ferries a similar field indicating whether cars are allowed should be added:

`cars_allowed` - Enum - Optional
Indicates whether cars are allowed. Valid options are:

`0` or empty - No car information for the trip.
`1` - Vehicle being used on this particular trip can accommodate at least one car.
`2` - No cars are allowed on this trip.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210563235088114