### PR TITLE
Update Schedule Revision history April 2025

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised Feb 24, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised May 6, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,8 @@
 ### Revision History
 
+#### April 2025
+* Added clarification to allow value 1 for continuous_pickup/continuous_drop_off for DRT services See [discussion](https://github.com/google/transit/pull/558).
+
 #### February 2025
 * Added rider_categories.txt. See [discussion](https://github.com/google/transit/pull/511).
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,7 +1,7 @@
 ### Revision History
 
 #### April 2025
-* Added clarification to allow value 1 for continuous_pickup/continuous_drop_off for DRT services See [discussion](https://github.com/google/transit/pull/558).
+* Added clarification to allow value 1 for continuous_pickup/continuous_drop_off for DRT services. See [discussion](https://github.com/google/transit/pull/558).
 
 #### February 2025
 * Added rider_categories.txt. See [discussion](https://github.com/google/transit/pull/511).


### PR DESCRIPTION
Update revision history with the changes merged in April 2025:

- https://github.com/google/transit/pull/558
