### PR TITLE
Correct trip_ids requirement and cardinality for selectedTrips

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -716,7 +716,7 @@ List of selected trips with an associated shape.
 
 | _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
 |------------------|------------|----------------|-------------------|-------------------|
-| **trip_ids** | [uint32](https://protobuf.dev/programming-guides/proto2/#scalar) | Many | One | A list of trip_id from the original (CSV) GTFS that are affected by the containing replacement. Need to contain at least one trip_id. A `TripUpdate` with `schedule_relationship=REPLACEMENT` must not already exist for the trip. |
+| **trip_ids** | [uint32](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | Many | A list of trip_id from the original (CSV) GTFS that are affected by the containing replacement. Need to contain at least one trip_id. A `TripUpdate` with `schedule_relationship=REPLACEMENT` must not already exist for the trip. |
 | **shape_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The ID of the new shape for the modified trips in this SelectedTrips. May refer to a new shape added using a `Shape` message in the same GTFS-RT feed, or to an existing shape defined in the GTFS-Static feed’s shapes.txt. If it refers to a `Shape` entity in the real-time feed, the value of this field should be the one of the `shape_id` inside the entity, and _not_ the `id` of `FeedEntity`. |
 
 ## _message_ ReplacementStop


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary
<!--Provide a brief summary of this proposal and the changes it introduces.-->
Found a typo in the RT spec. The requirement of `trip_ids` in SelectedTrips was "Many", which is probably the cardinality. The cardinality itself was set to "One", which probably should be "Many".

@gcamp does the change restore the correct requirement and cardinality for selectedTrips?

## Proposed Solution
<!--Provide a clear and concise description of the intended change.--> 
Change the requirement to "Required" and the cardinality to "Many".

## Type of change

<!--Please select the relevant change type.--> 

GTFS Schedule
- [ ] Functional Change
- [ ] Non-Functional Change
- [x] Documentation Maintenance

GTFS Realtime
- [ ] Specification Change
- [x] Specification Change (Experimental Field)

## Proposed Discussion Period
<!--Please specify a minimum estimated discussion period length based on the scope of the proposed change.* 
- *Example: “I recommend reserving at least one month for discussion to ensure everyone has sufficient time to discuss the proposal.”-->
This is a RT documentation change for an experimental field, I will leave a week for discussion and changes before merging the PR.

## Checklist

- [x] I have read and understood the [GTFS Change process](https://github.com/google/transit/tree/master/gtfs/Governance/change-process.md).
- [x] I have read and understood the [GTFS Guiding Principles](https://github.com/google/transit/tree/master/gtfs/Governance/guiding-principles.md). 
- [x] I understand the [Role of Advocate and the Responsibilities](https://github.com/google/transit/tree/master/gtfs/Governance/roles.md) attached to it. 
- [x] I have signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/about/google-individual).
- [x] I have ensured that this proposal is not covered by an existing Pull Request.
