### PR TITLE
Improve currency amount description

### DIFF
--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -460,7 +460,7 @@ Used to describe the range of fares available for purchase by riders or taken in
 | `fare_product_name` | Text | Optional | The name of the fare product as displayed to riders. |
 |  `rider_category_id` | Foreign ID referencing `rider_categories.rider_category_id` | Optional |  Identifies a rider category eligible for the fare product.<br><br>If `fare_products.rider_category_id` is empty, the fare product is eligible for any `rider_category_id`.<br><br>When multiple rider categories are eligible for a single fare product specified by a `fare_product_id`, there must be only one of these rider categories indicated as the default rider category (`is_default_fare_category = 1`). |
 |  `fare_media_id` | Foreign ID referencing `fare_media.fare_media_id` | Optional |  Identifies a fare media that can be employed to use the fare product during the trip. When `fare_media_id` is empty, it is considered that the fare media is unknown.|
-| `amount` | Currency amount | **Required** | The cost of the fare product. May be negative to represent transfer discounts. May be zero to represent a fare product that is free. |
+| `amount` | Currency amount | **Required** | The cost of the fare product. May be negative to represent transfer discounts. May be zero to represent a fare product that is free. The currency amount must contain the number of decimal places specified by the norm ISO 4217 for the accompanying Currency code.<hr>*Example: If the fare is 2 US Dollars, the amount is 2.00 instead of 2.* |
 | `currency` | Currency code | **Required** | The currency of the cost of the fare product. |
 
 


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary
This documentation change elaborates on the description of the "amount" field in `fare_products.txt`.

## Describe the Problem
There is a recurring practice of GTFS feeds having invalid currency amounts, e.g. If the fare is 2USD, the value of the field is specified as "**2**", instead of the norm-compliant "**2.00**".

The spec mentions the ISO 4217 norm in the field type description. However, if is beneficial to mention it again in the field description and to add an example.

## Type of change

<!--Please select the relevant change type.--> 

GTFS Schedule
- [ ] Functional Change
- [ ] Non-Functional Change
- [x] Documentation Maintenance

GTFS Realtime
- [x] Specification Change
- [ ] Specification Change (Experimental Field)

## Proposed Discussion Period
This is a documentation change. We will keep it up for a few days to get reviews, and then merge.

## Proposal Update Tracker 
<!--Track changes to this Pull Request post over time, including edits and updates to the proposal. Regularly update this section to summarize major points discussed in the PR, ensuring a clear record of key decisions and modifications.-->

| Date       | Update Description |
|------------|--------------------|
| (2026-02-23) | (Opened PR) |

## Checklist

- [x] I have read and understood the [GTFS Change process](https://github.com/google/transit/tree/master/gtfs/Governance/change-process.md).
- [x] I have read and understood the [GTFS Guiding Principles](https://github.com/google/transit/tree/master/gtfs/Governance/guiding-principles.md). 
- [x] I understand the [Role of Advocate and the Responsibilities](https://github.com/google/transit/tree/master/gtfs/Governance/roles.md) attached to it. 
- [x] I have signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/about/google-individual).
- [x] I have ensured that this proposal is not covered by an existing Pull Request.
