### PR TITLE
Update Revision History February 2026

### DIFF
--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -1,5 +1,10 @@
 ### Revision History
 
+#### February 2026
+
+* Corrected trip_ids requirement and cardinality for selectedTrips. See [discussion](https://github.com/google/transit/pull/609).
+* Added missing spaces. See [discussion](https://github.com/google/transit/pull/587).
+
 #### May 2025
 
 * Deprecates schedule_relationship `ADDED` in favour of `NEW` and adds `REPLACEMENT`. See [discussion](https://github.com/google/transit/pull/504).

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised October 28, 2025. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised March 3, 2026. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -4,6 +4,8 @@
 * Required `from_stop_id` and `to_stop_id` when transfer_type = 0 or is empty (recommended transfer point). See [discussion](https://github.com/google/transit/pull/591).
 * Improved currency amount description. See [discussion](https://github.com/google/transit/pull/615).
 * Clarified that fare transfer rules are directional. See [discussion](https://github.com/google/transit/pull/602).
+* Added links to references of `fare_leg_rules.txt`. See [discussion](https://github.com/google/transit/pull/601).
+* Added missing spaces. See [discussion](https://github.com/google/transit/pull/587).
 
 #### October 2025
 * Added clarifications for `fare_transfer_rules.txt` and introduced a new `Local Time` field type. See [discussion](https://github.com/google/transit/pull/561).

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,10 @@
 ### Revision History
 
+#### February 2026
+* Required `from_stop_id` and `to_stop_id` when transfer_type = 0 or is empty (recommended transfer point). See [discussion](https://github.com/google/transit/pull/591).
+* Improved currency amount description. See [discussion](https://github.com/google/transit/pull/615).
+* Clarified that fare transfer rules are directional. See [discussion](https://github.com/google/transit/pull/602).
+
 #### October 2025
 * Added clarifications for `fare_transfer_rules.txt` and introduced a new `Local Time` field type. See [discussion](https://github.com/google/transit/pull/561).
 


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary
This PR updates the revision history with the changes merged in February 2026:
- https://github.com/google/transit/pull/591
- https://github.com/google/transit/pull/615
- https://github.com/google/transit/pull/602
- https://github.com/google/transit/pull/601
- https://github.com/google/transit/pull/587
- https://github.com/google/transit/pull/609

