### PR TITLE
Add NewRoutes to GTFS-RT to support dynamic service (#606)

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1266,6 +1266,14 @@ message Route {
   // See definition of routes.route_sort_order in (CSV) GTFS.
   optional uint32 route_sort_order = 10;
 
+  // See definition of calendar.start_date in (CSV) GTFS.
+  // The first day that the new route is active, in YYYYMMDD format.
+  optional string start_date = 11;
+
+  // See definition of calendar.end_date in (CSV) GTFS.
+  // The last day that the new route is active, in YYYYMMDD format.
+  optional string end_date = 12;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1252,7 +1252,7 @@ message Route {
 
   // See definition of routes.route_type in (CSV) GTFS.
   // Required
-  optional RouteType route_type = 6;
+  optional int32 route_type = 6;
 
   // See definition of routes.route_url in (CSV) GTFS.
   optional TranslatedString route_url = 7;
@@ -1273,22 +1273,6 @@ message Route {
 
   // The following extension IDs are reserved for private use by any organization.
   extensions 9000 to 9999;
-}
-
-// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
-enum RouteType {
-  // route type as defined in the (CSV) GTFS
-
-  LIGHT_RAIL = 0;
-  SUBWAY = 1;
-  RAIL = 2;
-  BUS = 3;
-  FERRY = 4;
-  CABLE_CAR = 5;
-  GONDOLA = 6;
-  FUNICULAR = 7;
-  TROLLEY_BUS = 11;
-  MONORAIL = 12;
 }
 
 // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.

--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -113,6 +113,7 @@ message FeedEntity {
   optional Shape shape = 6;
   optional Stop stop = 7;
   optional TripModifications trip_modifications = 8;
+  optional Route route = 9;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
@@ -423,6 +424,10 @@ message TripUpdate {
     // Specifies the name for this trip when it differs from the original.
     // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
     optional string trip_short_name = 6;
+
+    // Specify the route associated with the trip, if the route has been added dynamically. The associated `Route` message should be included in the same feed.
+    // Optional if schedule_relationship is NEW, forbidden otherwise. 
+    optional string route_id = 7;
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
@@ -796,6 +801,8 @@ message TripDescriptor {
   optional string trip_id = 1;
 
   // The route_id from the GTFS that this selector refers to.
+  // This field is used to identify a trip inside an existing GTFS, not to dynamically create or insert new routes
+  // To assign routes dynamically, use the `trip_properties.route_id` field. 
   optional string route_id = 5;
 
   // The direction_id from the GTFS feed trips.txt file, indicating the
@@ -1220,6 +1227,68 @@ message TripModifications {
 
   // The following extension IDs are reserved for private use by any organization.
   extensions 9000 to 9999;
+}
+
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+message Route {
+  // Identifier of the route. Must be different than any route_id defined in the (CSV) GTFS.
+  // Required
+  optional string route_id = 1;
+
+  // See definition of routes.agency_id in (CSV) GTFS.
+  // Conditionally Required, see reference
+  optional string agency_id = 2;
+
+  // See definition of routes.route_short_name in (CSV) GTFS.
+  // Conditionally Required, see reference
+  optional TranslatedString route_short_name = 3;
+
+  // See definition of routes.route_long_name in (CSV) GTFS.
+  // Conditionally Required, see reference
+  optional TranslatedString route_long_name = 4;
+
+  // See definition of routes.route_desc in (CSV) GTFS.
+  optional TranslatedString route_desc = 5;
+
+  // See definition of routes.route_type in (CSV) GTFS.
+  // Required
+  optional RouteType route_type = 6;
+
+  // See definition of routes.route_url in (CSV) GTFS.
+  optional TranslatedString route_url = 7;
+
+  // See definition of routes.route_color in (CSV) GTFS.
+  optional string route_color = 8;
+
+  // See definition of routes.route_text_color in (CSV) GTFS.
+  optional string route_text_color = 9;
+
+  // See definition of routes.route_sort_order in (CSV) GTFS.
+  optional uint32 route_sort_order = 10;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+enum RouteType {
+  // route type as defined in the (CSV) GTFS
+
+  LIGHT_RAIL = 0;
+  SUBWAY = 1;
+  RAIL = 2;
+  BUS = 3;
+  FERRY = 4;
+  CABLE_CAR = 5;
+  GONDOLA = 6;
+  FUNICULAR = 7;
+  TROLLEY_BUS = 11;
+  MONORAIL = 12;
 }
 
 // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -742,9 +742,9 @@ Real-time information about a transit route. This message is used to dynamically
 | _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
 | :--- | :--- | :--- | :--- | :--- |
 | **route_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Identifier of the route. Must be different than any route_id defined in the static GTFS. |
-| **agency_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Agency which operates the route. See [routes.agency_id](https://gtfs.org/schedule/reference/#routestxt). |
-| **route_short_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Short name of the route. See [routes.route_short_name](https://gtfs.org/schedule/reference/#routestxt). |
-| **route_long_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Long name of the route. See [routes.route_long_name](https://gtfs.org/schedule/reference/#routestxt). |
+| **agency_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Conditionally Required | One | Agency which operates the route. See [routes.agency_id](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_short_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Conditionally Required | One | Short name of the route. See [routes.route_short_name](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_long_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Conditionally Required | One | Long name of the route. See [routes.route_long_name](https://gtfs.org/schedule/reference/#routestxt). |
 | **route_desc** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Description of the route. See [routes.route_desc](https://gtfs.org/schedule/reference/#routestxt). |
 | **route_type** | [int32](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Describes the type of transportation used on a route. See [routes.route_type](https://gtfs.org/schedule/reference/#routestxt). |
 | **route_url** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | URL of a web page about the route. See [routes.route_url](https://gtfs.org/schedule/reference/#routestxt). |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -138,7 +138,7 @@ A definition (or update) of an entity in the transit feed. If the entity is not 
 | **shape** | [Shape](#message-shape) | Conditionally required | One | Data about the realtime added shapes, such as for a detour. At least one of the fields trip_update, vehicle, alert, or shape must be provided - all these fields cannot be empty. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **stop** | [Stop](#message-stop) | Conditionally required | One | A new stop added to the feed dynamically. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **trip_modifications** | [TripModifications)(#message-tripmodifications) | Conditionally required | One | List of trips affected by a particular modifications, such as a detour. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
-
+| **route** | [Route](#message-route) | Conditionally required | One | Data about a new route added to the feed dynamically, such as a bus bridge. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 
 ## _message_ TripUpdate
 
@@ -735,3 +735,21 @@ _If a modification affects the first stop of the trip, that stop also serves as 
 |------------------|------------|----------------|-------------------|-------------------|
 | **stop_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The replacement stop ID which will now be visited by the trip. May refer to a new stop added using a GTFS-RT `Stop` message in the same GTFS-RT feed, or to an existing stop defined in the (CSV) GTFS feed’s `stops.txt`. If it refers to a `Shape` entity in the real-time feed, the value of this field should be the one of the `stop_id` inside the entity, and _not_ the `id` of `FeedEntity`. The stop MUST have `location_type=0` (routable stops). |
 | **travel_time_to_stop** | [int32](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | The difference in seconds between the arrival time at this stop and the arrival time at the reference stop. The reference stop is the stop prior to `start_stop_selector`. If the modification begins at the first stop of the trip, then the first stop of the trip is the reference stop. <br/><br/>This value MUST be monotonically increasing and may only be a negative number if the first stop of the original trip is the reference stop. <br/><br/>If the value is not supplied, consumers MAY interpolate or infer the `travel_time_to_stop` based on other data. |
+
+## _message_ Route
+Real-time information about a transit route. This message is used to dynamically define a route that does not exist in the static GTFS.
+
+| _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
+| :--- | :--- | :--- | :--- | :--- |
+| **route_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Identifier of the route. Must be different than any route_id defined in the static GTFS. |
+| **agency_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Agency which operates the route. See [routes.agency_id](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_short_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Short name of the route. See [routes.route_short_name](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_long_name** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Long name of the route. See [routes.route_long_name](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_desc** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Description of the route. See [routes.route_desc](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_type** | [int32](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | Describes the type of transportation used on a route. See [routes.route_type](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_url** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | URL of a web page about the route. See [routes.route_url](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_color** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Route color in RGB hex format. See [routes.route_color](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_text_color** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | Route text color in RGB hex format. See [routes.route_text_color](https://gtfs.org/schedule/reference/#routestxt). |
+| **route_sort_order** | [uint32](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | A non-negative integer used to specify the order in which the routes should be displayed. |
+| **start_date** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | The first day that the new route is active, in YYYYMMDD format. |
+| **end_date** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | The last day that the new route is active, in YYYYMMDD format. |


### PR DESCRIPTION
### Description
This proposal introduces a `NewRoutes` message to the `FeedEntity` in GTFS Realtime. As discussed in [Issue #606](https://github.com/google/transit/issues/606), the current specification lacks a standard way to define route metadata for services that do not exist in the static GTFS schedule.

The full technical specification and field definitions can be found in the [GTFS-NewRoutes Google Doc](https://docs.google.com/document/d/1Dv23vnycQcPBk1BRvDq5a_fL827up5SoYRZcnvar6m4/edit).

By allowing a `Route` to be defined directly within the real-time feed, consumers can provide a complete and accurate experience for riders without requiring agencies to "reuse" unrelated static IDs.

### Implementations
* **Producer:** [Clever Devices Test Feed](http://66.216.13.125:8080/gtfsrt/)
* **Consumer:** [Transit App](https://transitapp.com/) (Development in progress)
