### PR TITLE
fix: Remove SeverityLevel experimental note from reference

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -423,8 +423,6 @@ The effect of this problem on the affected entity.
 
 The severity of the alert.
 
-**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future.
-
 **Values**
 
 | _**Value**_ |


### PR DESCRIPTION
Removes note in `reference.md` warning that `SeverityLevel` is an experimental field. `SeverityLevel` was elevated to the full specification via #214.

In that 2020 pull request, the experimental tag was removed from the `severity_level` field in the `reference.md` file, as well as from the `gtfs-realtime.proto` file next to both the `severity_level` field and the `SeverityLevel` enum.

I believe maintaining the experimental tag for `SeverityLevel` within only `reference.md` is an oversight. Thus, this pull request is proposed as a non-functional update to the documentation, to ensure those users relying on the reference documentation are not misled about this field's status.