### PR TITLE
Update revision history - April 2026

### DIFF
--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -1,6 +1,6 @@
 ### Revision History
 
-#### February 2026
+#### April 2026
 
 * Fixed typos in gtfs-realtime.proto. See [discussion](https://github.com/google/transit/pull/541).
 

--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -2,6 +2,10 @@
 
 #### February 2026
 
+* Fixed typos in gtfs-realtime.proto. See [discussion](https://github.com/google/transit/pull/541).
+
+#### February 2026
+
 * Corrected trip_ids requirement and cardinality for selectedTrips. See [discussion](https://github.com/google/transit/pull/609).
 * Added missing spaces. See [discussion](https://github.com/google/transit/pull/587).
 

--- a/gtfs/spec/en/reference.md
+++ b/gtfs/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## General Transit Feed Specification Reference
 
-**Revised March 3, 2026. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
+**Revised April 27, 2026. See [Revision History](https://gtfs.org/schedule/process/#revision-history) for more details.**
 
 This document defines the format and structure of the files that comprise a GTFS dataset.
 

--- a/gtfs/spec/en/revision-history.md
+++ b/gtfs/spec/en/revision-history.md
@@ -1,5 +1,8 @@
 ### Revision History
 
+#### April 2026
+* Added safe duration fields to `trips.txt` to provide better flexible trip time estimates. See [discussion](https://github.com/google/transit/pull/598).
+
 #### February 2026
 * Required `from_stop_id` and `to_stop_id` when transfer_type = 0 or is empty (recommended transfer point). See [discussion](https://github.com/google/transit/pull/591).
 * Improved currency amount description. See [discussion](https://github.com/google/transit/pull/615).


### PR DESCRIPTION
This PR updates the revision history with the changes merged in April 2026:
- https://github.com/google/transit/pull/541
- https://github.com/google/transit/pull/598

I will merge this by the end of the week.