### PR TITLE
[Realtime] Clarify Trip Update precedence for consumer routing decisions

### DIFF
--- a/gtfs-realtime/spec/en/feed-entities.md
+++ b/gtfs-realtime/spec/en/feed-entities.md
@@ -32,6 +32,13 @@ A service alert will usually consist of some text which will describe the
 problem, and we also allow for URLs for more information as well as more
 structured information to help us understand who this service alert affects.
 
+#### Interaction between Trip Updates and Service Alerts
+
+If data consumers use Service Alerts to affect routing results, and both Trip Updates
+and Service Alerts apply but provide conflicting information, consumers should
+give precedence to Trip Updates for routing results, unless there is clear
+evidence that the Trip Updates is incorrect.
+
 [More about Service Alerts...](service-alerts.md)
 
 ## Vehicle Positions

--- a/gtfs-realtime/spec/en/feed-entities.md
+++ b/gtfs-realtime/spec/en/feed-entities.md
@@ -34,9 +34,9 @@ structured information to help us understand who this service alert affects.
 
 #### Interaction between Trip Updates and Service Alerts
 
-If data consumers use Service Alerts to affect routing results, and both Trip Updates
+If data consumers use Service Alerts to affect routing decisions, and both Trip Updates
 and Service Alerts apply but provide conflicting information, consumers should
-give precedence to Trip Updates for routing results, unless there is clear
+give precedence to Trip Updates for routing decisions, unless there is clear
 evidence that the Trip Updates is incorrect.
 
 [More about Service Alerts...](service-alerts.md)


### PR DESCRIPTION
### Context

MobilityData is currently developing Service Alerts guidance to help the community use Service Alerts more consistently. As part of this work, we are gathering feedback through the Service Alerts Working Group meeting.

In the Apr 28 meeting, we discussed how consumers should interpret cases where both Trip Updates and Service Alerts apply but provide conflicting information. The group reached consensus that consumers should by default **give precedence to Trip Updates** for routing decisions.

### Proposed change

This PR adds a clarification to `feed-entities.md` describing the expected consumer behavior when Trip Updates and Service Alerts both apply.

While this clarification will also be included in the Service Alerts guidance, we believe it is appropriate to include it directly in the specification as well, in order to make this shared expectation clearer.

Because this change clarifies a principle for expected consumer behavior, and does not introduce a new field or functional change, I propose that it can proceed to a vote without requiring implementation testing.

### Additional information

[Here is the working group meeting notes](https://docs.google.com/document/d/1rL04SPOPzGxpAO2KikzH6F1QV-Zr25iZvdwCmRGaI5w/edit?tab=t.0)

We also plan to add an additional Service Alerts meeting in July to continue discussing guidance around Service Alert usage. [Registration page](https://community.mobilitydata.org/working-groups#events)