### PR TITLE
Markdown errors correction and formatting suggestions

### DIFF
--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -112,15 +112,12 @@ Metadata about a feed, included in feed messages.
 
 Determines whether the current fetch is incremental.
 
-*   **FULL_DATASET**: this feed update will overwrite all preceding realtime information for the feed. Thus this update is expected to provide a full snapshot of all known realtime information.
-*   **DIFFERENTIAL**: currently, this mode is **unsupported** and behavior is **unspecified** for feeds that use this mode. There are discussions on the [GTFS Realtime mailing list](http://groups.google.com/group/gtfs-realtime) around fully specifying the behavior of DIFFERENTIAL mode and the documentation will be updated when those discussions are finalized.
-
 **Values**
 
-| _**Value**_ |
-|-------------|
-| **FULL_DATASET** |
-| **DIFFERENTIAL** |
+| _**Value**_ | _**Comment**_ |
+|-------------|---------------|
+| **FULL_DATASET** | This feed update will overwrite all preceding realtime information for the feed. Thus this update is expected to provide a full snapshot of all known realtime information. |
+| **DIFFERENTIAL** | Currently, this mode is **unsupported** and behavior is **unspecified** for feeds that use this mode. There are discussions on the [GTFS Realtime mailing list](http://groups.google.com/group/gtfs-realtime) around fully specifying the behavior of DIFFERENTIAL mode and the documentation will be updated when those discussions are finalized. |
 
 ## _message_ FeedEntity
 
@@ -137,7 +134,7 @@ A definition (or update) of an entity in the transit feed. If the entity is not 
 | **alert** | [Alert](#message-alert) | Conditionally required | One | Data about the realtime alert. At least one of the fields trip_update, vehicle, alert, or shape must be provided - all these fields cannot be empty. |
 | **shape** | [Shape](#message-shape) | Conditionally required | One | Data about the realtime added shapes, such as for a detour. At least one of the fields trip_update, vehicle, alert, or shape must be provided - all these fields cannot be empty. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 | **stop** | [Stop](#message-stop) | Conditionally required | One | A new stop added to the feed dynamically. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
-| **trip_modifications** | [TripModifications)(#message-tripmodifications) | Conditionally required | One | List of trips affected by a particular modifications, such as a detour. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
+| **trip_modifications** | [TripModifications](#message-tripmodifications) | Conditionally required | One | List of trips affected by a particular modifications, such as a detour. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
 
 
 ## _message_ TripUpdate
@@ -253,9 +250,9 @@ Realtime update for certain properties defined within GTFS stop_times.txt.
 
 ## _message_ TripProperties
 
-Defines updated properties of the trip
+Defines updated properties of the trip.
 
-**Caution:** this message is still **experimental**, and subject to change. It may be formally adopted in the future.<br>.
+**Caution:** this message is still **experimental**, and subject to change. It may be formally adopted in the future.<br>
 
 **Fields**
 
@@ -327,15 +324,15 @@ For describing passenger occupancy levels on a linear scale, see `occupancy_perc
 
 | _**Value**_ | _**Comment**_ |
 |-------------|---------------|
-| _**EMPTY**_ | _The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers._ |
-| _**MANY_SEATS_AVAILABLE**_ | _The vehicle or carriage has a large number of seats available. The amount of free seats out of the total seats available to be considered large enough to fall into this category is determined at the discretion of the producer._ |
-| _**FEW_SEATS_AVAILABLE**_ | _The vehicle or carriage has a small number of seats available. The amount of free seats out of the total seats available to be considered small enough to fall into this category is determined at the discretion of the producer._ |
-| _**STANDING_ROOM_ONLY**_ | _The vehicle or carriage can currently accommodate only standing passengers._ |
-| _**CRUSHED_STANDING_ROOM_ONLY**_ | _The vehicle or carriage can currently accommodate only standing passengers and has limited space for them._ |
-| _**FULL**_ | _The vehicle is considered full by most measures, but may still be allowing passengers to board._ |
-| _**NOT_ACCEPTING_PASSENGERS**_ | _The vehicle or carriage is not accepting passengers. The vehicle or carriage usually accepts passengers for boarding._ |
-| _**NO_DATA_AVAILABLE**_ | _The vehicle or carriage doesn't have any occupancy data available at that time._ |
-| _**NOT_BOARDABLE**_ | _The vehicle or carriage is not boardable and never accepts passengers. Useful for special vehicles or carriages (engine, maintenance carriage, etc…)._ |
+| **EMPTY** | The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers. |
+| **MANY_SEATS_AVAILABLE** | The vehicle or carriage has a large number of seats available. The amount of free seats out of the total seats available to be considered large enough to fall into this category is determined at the discretion of the producer. |
+| **FEW_SEATS_AVAILABLE** | The vehicle or carriage has a small number of seats available. The amount of free seats out of the total seats available to be considered small enough to fall into this category is determined at the discretion of the producer. |
+| **STANDING_ROOM_ONLY** | The vehicle or carriage can currently accommodate only standing passengers. |
+| **CRUSHED_STANDING_ROOM_ONLY** | The vehicle or carriage can currently accommodate only standing passengers and has limited space for them. |
+| **FULL** | The vehicle is considered full by most measures, but may still be allowing passengers to board. |
+| **NOT_ACCEPTING_PASSENGERS** | The vehicle or carriage is not accepting passengers. The vehicle or carriage usually accepts passengers for boarding. |
+| **NO_DATA_AVAILABLE** | The vehicle or carriage doesn't have any occupancy data available at that time. |
+| **NOT_BOARDABLE** | The vehicle or carriage is not boardable and never accepts passengers. Useful for special vehicles or carriages (engine, maintenance carriage, etc…). |
 
 
 ## _message_ CarriageDetails
@@ -516,10 +513,11 @@ When a service is affected by a trip modification, `ModifiedTripSelector` is use
 **Values**
 
 | _**Field Name**_ | _**Type**_ | _**Required**_ | _**Cardinality**_ | _**Description**_ |
-| **modifications_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The `id` of the `FeedEntity` in which the contained `TripModifications` object affects this trip.
-| **affected_trip_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The `trip_id` from the GTFS feed that is modified by the `modifications_id`
-| **start_time** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | The initially scheduled start time of this trip instance, applied to the frequency based modified trip. Same definition as **start_time** in [TripDescriptor](#message-tripdescriptor).
-| **start_date** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One |  The start date of this trip instance in YYYYMMDD format, applied to the modified trip. Same definition as **start_date** in [TripDescriptor](#message-tripdescriptor).
+|------------------|------------|----------------|-------------------|-------------------|
+| **modifications_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The `id` of the `FeedEntity` in which the contained `TripModifications` object affects this trip. |
+| **affected_trip_id** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Required | One | The `trip_id` from the GTFS feed that is modified by the `modifications_id` |
+| **start_time** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One | The initially scheduled start time of this trip instance, applied to the frequency based modified trip. Same definition as **start_time** in [TripDescriptor](#message-tripdescriptor). |
+| **start_date** | [string](https://protobuf.dev/programming-guides/proto2/#scalar) | Optional | One |  The start date of this trip instance in YYYYMMDD format, applied to the modified trip. Same definition as **start_date** in [TripDescriptor](#message-tripdescriptor). |
 
 ## _message_ VehicleDescriptor
 


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary

This PR solves three small Markdown formatting problems (a link, a table, an extra dot), and suggests two modifications for consistency.

## Describe the Problem

- _enum_ Incrementality displays a description of its values in a list, not a table, unlike the other enums.
- A TripModifications link does not show properly.
- Extra . after a line break
- The _enum_ OccupancyStatus table is all in italics, unlike all other tables.
- A table was not being rendered as table due to formatting errors.

## Use Cases

N/A

## Proposed Solution

- Move Incrementality information to a table with Value and Comment.
- Correct TripModifications link (wrong parentheses).
- Remove extra . after line break.
- Remove italics from OccupancyStatus table.
- Format ModifiedTripSelector table properly (missing required header separator row).

## Type of change

<!--Please select the relevant change type.--> 

GTFS Schedule
- [ ] Functional Change
- [ ] Non-Functional Change
- [ ] Documentation Maintenance

GTFS Realtime
- [x] Specification Change
- [x] Specification Change (Experimental Field)

## Additional Information

N/A

## Proposed Discussion Period

N/A

## Testing Details

N/A

## Proposal Update Tracker 

N/A

## Checklist

- [x] I have read and understood the [GTFS Change process](https://github.com/google/transit/tree/master/gtfs/Governance/change-process.md).
- [x] I have read and understood the [GTFS Guiding Principles](https://github.com/google/transit/tree/master/gtfs/Governance/guiding-principles.md). 
- [x] I understand the [Role of Advocate and the Responsibilities](https://github.com/google/transit/tree/master/gtfs/Governance/roles.md) attached to it. 
- [x] I have signed the [Contributor License Agreement (CLA)](https://cla.developers.google.com/about/google-individual).
- [x] I have ensured that this proposal is not covered by an existing Pull Request.
