### PR TITLE
Update Revision History - June 2026

### DIFF
--- a/gtfs-realtime/spec/en/revision-history.md
+++ b/gtfs-realtime/spec/en/revision-history.md
@@ -1,5 +1,10 @@
 ### Revision History
 
+#### June 2026
+
+* Added two new fields into Service Alerts: communication_period and impact_period to better define active_period. See [discussion](https://github.com/google/transit/pull/546)
+* Added new SPECIAL_EVENT Cause to Cause list in Service Alerts. See [discussion](https://github.com/google/transit/pull/577)
+
 #### April 2026
 
 * Fixed typos in gtfs-realtime.proto. See [discussion](https://github.com/google/transit/pull/541).


### PR DESCRIPTION
This PR updates the revision history with the changes merged in June 2026:

- https://github.com/google/transit/pull/546 
- https://github.com/google/transit/pull/577

Changes will be merged in 7 days.