### PR TITLE
Clarify spec: Add definitions to Cause and Effect values and clarify Trip Update and Service Alerts usage for consumer routing decisions

### DIFF
--- a/gtfs-realtime/spec/en/feed-entities.md
+++ b/gtfs-realtime/spec/en/feed-entities.md
@@ -32,6 +32,13 @@ A service alert will usually consist of some text which will describe the
 problem, and we also allow for URLs for more information as well as more
 structured information to help us understand who this service alert affects.
 
+#### Interaction between Trip Updates and Service Alerts
+
+If data consumers use Service Alerts to affect routing decisions, and both Trip Updates
+and Service Alerts apply but provide conflicting information, consumers should
+give precedence to Trip Updates for routing decisions, unless there is clear
+evidence that the Trip Updates is incorrect.
+
 [More about Service Alerts...](service-alerts.md)
 
 ## Vehicle Positions

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -413,7 +413,7 @@ The effect of this problem on the affected entity.
 | **NO_SERVICE** | No transit service to the specified entity(-ies).<br>- For stations or stops, the rider will not be able to board or alight.<br>- For routes, the route will not run.<br>- For trips, those specific trips are cancelled. |
 | **REDUCED_SERVICE** | The number or frequency of trips is reduced. |
 | **SIGNIFICANT_DELAYS** | The route will consistently run late (insignificant delays should only be provided through [Trip updates](trip-updates.md)). |
-| **DETOUR** | The route changes its shape, resulting in the route not serving one or multiple stops or picking up/dropping off at other locations. |
+| **DETOUR** | The route changes its shape, resulting in the route not serving one or multiple stops, or picking up/dropping off at other locations. |
 | **ADDITIONAL_SERVICE** | The number or frequency of trips is increased. For example, more buses are running to cover for a special event. |
 | **MODIFIED_SERVICE** | Operations are different from what the rider would normally expect. An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week. |
 | **OTHER_EFFECT** | Not represented by any of these options. |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -410,10 +410,10 @@ The effect of this problem on the affected entity.
 
 | _**Value**_ | _**Comment**_ |
 |-------------|----------------|
-| **NO_SERVICE** | No transit service to the specified entity(-ies). For stations or stops, the rider will not be able to board or alight. For routes, the route will not run. For trips, those specific trips are cancelled. |
+| **NO_SERVICE** | No transit service to the specified entity(-ies).<br>- For stations or stops, the rider will not be able to board or alight.<br>- For routes, the route will not run.<br>- For trips, those specific trips are cancelled. |
 | **REDUCED_SERVICE** | The number or frequency of trips is reduced. |
-| **SIGNIFICANT_DELAYS** | The route will consistently run late (insignificant delays should only be provided through Trip updates). |
-| **DETOUR** | The route changes its shape, resulting in one or multiple stops being moved. |
+| **SIGNIFICANT_DELAYS** | The route will consistently run late (insignificant delays should only be provided through [Trip updates](trip-updates.md)). |
+| **DETOUR** | The route changes its shape, resulting in the route not serving one or multiple stops or picking up/dropping off at other locations. |
 | **ADDITIONAL_SERVICE** | The number or frequency of trips is increased. For example, more buses are running to cover for a special event. |
 | **MODIFIED_SERVICE** | Operations are different from what the rider would normally expect. An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week. |
 | **OTHER_EFFECT** | Not represented by any of these options. |

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -386,21 +386,21 @@ Cause of this alert.
 
 **Values**
 
-| _**Value**_ |
-|-------------|
-| **UNKNOWN_CAUSE** |
-| **OTHER_CAUSE** |
-| **TECHNICAL_PROBLEM** |
-| **STRIKE** |
-| **DEMONSTRATION** |
-| **ACCIDENT** |
-| **HOLIDAY** |
-| **WEATHER** |
-| **MAINTENANCE** |
-| **CONSTRUCTION** |
-| **POLICE_ACTIVITY** |
-| **MEDICAL_EMERGENCY** |
-| **SPECIAL_EVENT** |
+| _**Value**_ | _**Comment**_ |
+|-------------|----------------|
+| **UNKNOWN_CAUSE** | Used when the cause of the disruption is not known or has not been determined. Should be avoided if any more specific cause can be reasonably identified. |
+| **OTHER_CAUSE** | Used for causes that do not represented by any of predefined options. |
+| **TECHNICAL_PROBLEM** | Issues related to vehicles or infrastructure malfunctioning. Examples include mechanical failure and information system bugs. |
+| **STRIKE** | Service disruptions caused by a labor strike involving the transit agency or operator. |
+| **DEMONSTRATION** | Service disruptions caused by public demonstration, protest, or gathering. |
+| **ACCIDENT** | Incidents such as collisions or derailments that disrupt services. |
+| **HOLIDAY** | Any public holiday that might result in a change of service. |
+| **WEATHER** | Disruptions caused by weather conditions such as snow, storms, flooding, etc. |
+| **MAINTENANCE** | Planned maintenance related to the services. Examples include track maintenance, elevator maintenance and vehicle maintenance. |
+| **CONSTRUCTION** | Any construction that affects the service, regardless whether it relates to the services or not. Examples include station construction and roadworks that affect bus routes. |
+| **POLICE_ACTIVITY** | Disruptions due to law enforcement activity or security incidents. Examples include investigations or security threats. |
+| **MEDICAL_EMERGENCY** | Incidents involving passenger or staff medical emergencies. Examples include an on-board medical problem that forces a train to stop. |
+| **SPECIAL_EVENT** | A special one-time or recurring event such as a parade, festival, performance, farmers market, or sporting event. |
 
 ## _enum_ Effect
 
@@ -408,19 +408,19 @@ The effect of this problem on the affected entity.
 
 **Values**
 
-| _**Value**_ |
-|-------------|
-| **NO_SERVICE** |
-| **REDUCED_SERVICE** |
-| **SIGNIFICANT_DELAYS** |
-| **DETOUR** |
-| **ADDITIONAL_SERVICE** |
-| **MODIFIED_SERVICE** |
-| **OTHER_EFFECT** |
-| **UNKNOWN_EFFECT** |
-| **STOP_MOVED** |
-| **NO_EFFECT** |
-| **ACCESSIBILITY_ISSUE** |
+| _**Value**_ | _**Comment**_ |
+|-------------|----------------|
+| **NO_SERVICE** | No transit service to the specified entity(-ies). For stations or stops, the rider will not be able to board or alight. For routes, the route will not run. For trips, those specific trips are cancelled. |
+| **REDUCED_SERVICE** | The number or frequency of trips is reduced. |
+| **SIGNIFICANT_DELAYS** | The route will consistently run late (insignificant delays should only be provided through Trip updates). |
+| **DETOUR** | The route changes its shape, resulting in one or multiple stops being moved. |
+| **ADDITIONAL_SERVICE** | The number or frequency of trips is increased. For example, more buses are running to cover for a special event. |
+| **MODIFIED_SERVICE** | Operations are different from what the rider would normally expect. An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week. |
+| **OTHER_EFFECT** | Not represented by any of these options. |
+| **UNKNOWN_EFFECT** | Used for alerts whose effect has not been identified yet. Do not use "Unknown effect" if the effect of the alert is known or can be deduced from the alert header or description. |
+| **STOP_MOVED** | A stop location is changed temporarily or permanently (if known to be permanent, ensure the new location is reflected in the schedule data). |
+| **NO_EFFECT** | The alert provides information to riders but does not affect operations. Examples include advertising public meetings and soliciting feedback via surveys. Unless necessary, it is advised not to use this effect. |
+| **ACCESSIBILITY_ISSUE** | The alert provides information about accessibility issues that affect step-free access. Examples include an out of service elevator or movable ramps, a bus that is unable to kneel, or an exceptional service with trains that have a big platform gap. |
 
 ## _enum_ SeverityLevel
 

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -32,32 +32,35 @@ If you would like to represent an alert that affects more than one entity (e.g. 
 
 What is the cause of this alert? You may specify one of the following:
 
-*   Unknown cause
-*   Other cause (not represented by any of these options)
-*   Technical problem
-*   Strike
-*   Demonstration
-*   Accident
-*   Holiday
-*   Weather
-*   Maintenance
-*   Construction
-*   Police activity
-*   Medical emergency
-*   Special Event
+* **Unknown cause**: Used when the cause of the disruption is not known or has not been determined. Should be avoided if any more specific cause can be reasonably identified.
+* **Other cause**: Used for causes that do not represented by any of predefined options.
+* **Technical problem**: Issues related to vehicles or infrastructure malfunctioning. Examples include mechanical failure and information system bugs.
+* **Strike**: Service disruptions caused by a labor strike involving the transit agency or operator.
+* **Demonstration**: Service disruptions caused by public demonstration, protest, or gathering.
+* **Accident**: Incidents such as collisions or derailments that disrupt services.
+* **Holiday**: Any public holiday that might result in a change of service.
+* **Weather**: Disruptions caused by weather conditions such as snow, storms, flooding, etc.
+* **Maintenance**: Planned maintenance related to the services. Examples include track maintenance, elevator maintenance and vehicle maintenance.
+* **Construction**: Any construction that affects the service, regardless whether it relates to the services or not. Examples include station construction and roadworks that affect bus routes.
+* **Police activity**: Disruptions due to law enforcement activity or security incidents. Examples include investigations or security threats.
+* **Medical emergency**: Incidents involving passenger or staff medical emergencies. Examples include an on-board medical problem that forces a train to stop.
+* **Special Event**: A special one-time or recurring event such as a parade, festival, performance, farmers market, or sporting event.
 
 ## Effect
 
 What effect does this problem have on the specified entity? You may specify one of the following:
 
-*   No service
-*   Reduced service
-*   Significant delays (insignificant delays should only be provided through [Trip updates](trip-updates.md)).
-*   Detour
-*   Additional service
-*   Modified service: Operations are different from what the rider would normally expect.  An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week.
-*   Stop moved
-*   Other effect (not represented by any of these options)
-*   Unknown effect
-*   No effect: The alert provides information to riders but does not affect operations.  Examples include advertising public meetings and soliciting feedback via surveys.
-*   Accessibility issue: The alert provides information about accessibility issues that affects step-free access. Examples include an out of service elevator or movable ramps.
+* **No service**: No transit service to the specified entity(-ies).
+  * For stations or stops, the rider will not be able to board or alight.
+  * For routes, the route will not run.
+  * For trips, those specific trips are cancelled.
+* **Reduced service**: The number or frequency of trips is reduced.
+* **Significant delays**: The route will consistently run late (insignificant delays should only be provided through [Trip updates](trip-updates.md)).
+* **Detour**: The route changes its shape, resulting in one or multiple stops being moved.
+* **Additional service**: The number or frequency of trips is increased. For example, more buses are running to cover for a special event.
+* **Modified service**: Operations are different from what the rider would normally expect. An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week.
+* **Stop moved**: A stop location is changed temporarily or permanently (if known to be permanent, ensure the new location is reflected in the schedule data).
+* **Other effect** (not represented by any of these options).
+* **Unknown effect**: Used for alerts whose effect has not been identified yet. Do not use “Unknown effect” if the effect of the alert is known or can be deduced from the alert header or description.
+* **No effect**: The alert provides information to riders but does not affect operations. Examples include advertising public meetings and soliciting feedback via surveys. Unless necessary, it is advised not to use this effect.
+* **Accessibility issue**: The alert provides information about accessibility issues that affect step-free access. Examples include an out of service elevator or movable ramps, a bus that is unable to kneel, or an exceptional service with trains that have a big platform gap.

--- a/gtfs-realtime/spec/en/service-alerts.md
+++ b/gtfs-realtime/spec/en/service-alerts.md
@@ -56,11 +56,11 @@ What effect does this problem have on the specified entity? You may specify one 
   * For trips, those specific trips are cancelled.
 * **Reduced service**: The number or frequency of trips is reduced.
 * **Significant delays**: The route will consistently run late (insignificant delays should only be provided through [Trip updates](trip-updates.md)).
-* **Detour**: The route changes its shape, resulting in one or multiple stops being moved.
+* **Detour**: The route changes its shape, resulting in the route not serving one or multiple stops, or picking up/dropping off at other locations.
 * **Additional service**: The number or frequency of trips is increased. For example, more buses are running to cover for a special event.
 * **Modified service**: Operations are different from what the rider would normally expect. An example is an alert that reminds riders of an upcoming holiday schedule that is different from normal service on that day of the week.
 * **Stop moved**: A stop location is changed temporarily or permanently (if known to be permanent, ensure the new location is reflected in the schedule data).
-* **Other effect** (not represented by any of these options).
+* **Other effect** Not represented by any of these options.
 * **Unknown effect**: Used for alerts whose effect has not been identified yet. Do not use “Unknown effect” if the effect of the alert is known or can be deduced from the alert header or description.
 * **No effect**: The alert provides information to riders but does not affect operations. Examples include advertising public meetings and soliciting feedback via surveys. Unless necessary, it is advised not to use this effect.
 * **Accessibility issue**: The alert provides information about accessibility issues that affect step-free access. Examples include an out of service elevator or movable ramps, a bus that is unable to kneel, or an exceptional service with trains that have a big platform gap.


### PR DESCRIPTION
<!--USE THIS TEMPLATE AS A REFERENCE AND MODIFY AND REMOVE SECTIONS TO BEST FIT YOUR PROPOSAL-->

## Summary
<!--Provide a brief summary of this proposal and the changes it introduces.-->
MobilityData is currently developing Service Alerts guidance to help the community use Service Alerts more consistently. As part of this work, we are gathering feedback through the Service Alerts Working Group meeting.

In the Apr 28th, 2026 meeting, we presented and discussed detailed definitions of values for the Cause and Effect fields, drafted [here](https://docs.google.com/document/d/1U_al9cyN8OVWJqzyiENB1imWgX9KrsUL5AViUpHswPs/edit?usp=sharing),  to make sure that producers are attributing the correct values to real-world cases.

In addition, we discussed how consumers should interpret cases where both Trip Updates and Service Alerts apply but provide conflicting information. The group reached consensus that consumers should ~~by default give precedence to Trip Updates for routing decisions.~~ use both to inform routing decisions, and that producers should have the highest quality possible in their trip updates feeds.

## Proposed Solution
<!--Provide a clear and concise description of the intended change.--> 

This PR
1) Adds a clarification to `feed-entities.md` describing that both trip updates and services alerts should be used to inform routing decisions. And that trip updates must always be accurate to what is happening in the transit network.
While this clarification will also be included in the Service Alerts guidance, we believe it is appropriate to include it directly in the specification as well, in order to make this shared expectation clearer.

2) Details the definitions for values of Cause and Effect, to make sure that service alerts are correctly categorized.

These changes are intended to clarify definitions and to clarify a principle for expected consumer behaviour, and they do not introduce a new field or functional change. Therefore, I propose that it can proceed to a vote without requiring implementation testing.

## Type of change

<!--Please select the relevant change type.--> 

GTFS Schedule
- [ ] Functional Change
- [ ] Non-Functional Change
- [ ] Documentation Maintenance

GTFS Realtime
- [x] Specification Change
- [ ] Specification Change (Experimental Field)

### Additional information

[Here is the working group meeting notes](https://docs.google.com/document/d/1rL04SPOPzGxpAO2KikzH6F1QV-Zr25iZvdwCmRGaI5w/edit?tab=t.0)

We also plan to add an additional Service Alerts meeting in July to continue discussing guidance around Service Alert usage. [Registration page](https://community.mobilitydata.org/working-groups#events)