### PR TITLE
Mark images in Service Alerts as final

### DIFF
--- a/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/gtfs-realtime/proto/gtfs-realtime.proto
@@ -708,12 +708,10 @@ message Alert {
 
   // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
   // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. 
-  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedImage image = 15;
 
   // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
   // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
-  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
   optional TranslatedString image_alternative_text = 16;
 
 
@@ -1055,7 +1053,6 @@ message TranslatedString {
 //    translation, the first matching translation is picked.
 // 3. If some translation has an unspecified language code, that translation is
 //    picked.
-// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
 message TranslatedImage {
   message LocalizedImage {
     // String containing an URL linking to an image

--- a/gtfs-realtime/spec/en/reference.md
+++ b/gtfs-realtime/spec/en/reference.md
@@ -376,8 +376,8 @@ An alert, indicating some sort of incident in the public transit network.
 | **tts_header_text** | [TranslatedString](#message-translatedstring) | Optional | One | Text containing the alert's header to be used for text-to-speech implementations. This field is the text-to-speech version of header_text. It should contain the same information as header_text but formatted such that it can read as text-to-speech (for example, abbreviations removed, numbers spelled out, etc.) |
 | **tts_description_text** | [TranslatedString](#message-translatedstring) | Optional | One | Text containing a description for the alert to be used for text-to-speech implementations. This field is the text-to-speech version of description_text. It should contain the same information as description_text but formatted such that it can be read as text-to-speech (for example, abbreviations removed, numbers spelled out, etc.) |
 | **severity_level** | [SeverityLevel](#enum-severitylevel) | Optional | One | Severity of the alert. |
-| **image** | [TranslatedImage](#message-translatedimage) | Optional | One | TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image should enhance the understanding of the alert and must not be the only location of essential information. The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
-| **image_alternative_text** | [TranslatedString](#message-translatedstring) | Optional | One | Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed or the user can't see the image for accessibility reasons). See the HTML [spec for alt image text](https://html.spec.whatwg.org/#alt). <br><br>**Caution:** this field is still **experimental**, and subject to change. It may be formally adopted in the future. |
+| **image** | [TranslatedImage](#message-translatedimage) | Optional | One | TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image should enhance the understanding of the alert and must not be the only location of essential information. The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. |
+| **image_alternative_text** | [TranslatedString](#message-translatedstring) | Optional | One | Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed or the user can't see the image for accessibility reasons). See the HTML [spec for alt image text](https://html.spec.whatwg.org/#alt). |
 
 
 ## _enum_ Cause
@@ -588,8 +588,6 @@ A localized string mapped to a language.
 ## _message_ TranslatedImage
 
 An internationalized message containing per-language versions of an image. One of the images from a message will be picked up. The resolution proceeds as follows: If the UI language matches the language code of a translation, the first matching translation is picked. If a default UI language (e.g., English) matches the language code of a translation, the first matching translation is picked. If some translation has an unspecified language code, that translation is picked.
-
-**Caution:** this message is still **experimental**, and subject to change. It may be formally adopted in the future.
 
 **Fields**
 


### PR DESCRIPTION
## Summary

`image`, `image_alternative_text` and the `TranslatedImage` message have been in the spec since [September 2021](https://github.com/google/transit/pull/283). This PR removes their experimental tag.

## Type of change

GTFS Realtime
- [X] Specification Change

## Proposed Discussion Period

7 calendar day (minimum)

## Testing Details

- Consumer(s): Transit
- Producer(s): Metro Transit (Minneapolis), TransLink (Vancouver), MBTA (Boston), VTA (Bay Area), [Mecatran](mecatran.com).

One caveat on the consumer side: Transit parses both fields and can display the image alongside the alert, but it isn't enabled by default today — it has to be manually enabled for the image to be shown to riders. There's plans to show it by default in the future. In the list of producers, we currently only show Metro Transit and TransLink. 

| Minneapolis | Vancouver |
| ------  | ----  |
| <img width="590" height="1278" alt="Capture d’écran, le 2026-07-29 à 13 39 26" src="https://github.com/user-attachments/assets/16ba482f-1f7d-4bcf-918c-93056c4c2c86" /> | <img width="590" height="1278" alt="Capture d’écran, le 2026-07-29 à 13 37 53" src="https://github.com/user-attachments/assets/59ce2f41-1a4f-49ce-a5f6-8a369277bcce" /> |

## Proposal Update Tracker

| Date       | Update Description |
|------------|--------------------|
| 2026-07-29 | Initial PR submission |
